### PR TITLE
Move Okta FastPass to configuration and disable Selenium telemetry

### DIFF
--- a/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
+++ b/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
@@ -20,6 +20,7 @@ public class ConfigurationDialog extends JDialog {
     private JCheckBox storePasswordCheckBox;
     private JSpinner passwordExpirationSpinner;
     private JComboBox<String> themeComboBox;
+    private JCheckBox useFastPassCheckBox;
     private JButton saveButton;
     private JButton cancelButton;
 
@@ -88,6 +89,12 @@ public class ConfigurationDialog extends JDialog {
         }
         mainPanel.add(themeComboBox, gbc);
 
+        // FastPass option
+        gbc.gridx = 0; gbc.gridy = 4; gbc.gridwidth = 2;
+        useFastPassCheckBox = new JCheckBox("Use Okta FastPass");
+        mainPanel.add(useFastPassCheckBox, gbc);
+        gbc.gridwidth = 1;
+
         add(mainPanel, BorderLayout.CENTER);
 
         // Button panel
@@ -117,6 +124,8 @@ public class ConfigurationDialog extends JDialog {
 
         themeComboBox.setSelectedItem(databaseManager.getTheme());
 
+        useFastPassCheckBox.setSelected(databaseManager.getFastPassEnabled());
+
         updatePasswordExpirationEnabled();
     }
 
@@ -137,8 +146,11 @@ public class ConfigurationDialog extends JDialog {
                 String selectedTheme = (String) themeComboBox.getSelectedItem();
                 databaseManager.setTheme(selectedTheme);
 
-                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}",
-                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme);
+                boolean useFastPass = useFastPassCheckBox.isSelected();
+                databaseManager.setFastPassEnabled(useFastPass);
+
+                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, use_fastpass = {}",
+                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, useFastPass);
 
                 // Apply theme immediately
                 if (ThemeManager.applyTheme(selectedTheme)) {

--- a/src/main/java/com/ourgiant/saml/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/DatabaseManager.java
@@ -76,7 +76,8 @@ public class DatabaseManager {
             "session_duration", "14400", // 4 hours in seconds
             "min_duration", "900",      // 15 minutes in seconds
             "max_duration", "28800",    // 8 hours in seconds
-            "theme", "Flat Dark"        // Default to Flat Dark theme
+            "theme", "Flat Dark",       // Default to Flat Dark theme
+            "use_fastpass", "false"     // FastPass disabled by default
         };
 
         String insertSQL = "INSERT OR IGNORE INTO config (key, value) VALUES (?, ?)";
@@ -151,6 +152,15 @@ public class DatabaseManager {
 
     public void setTheme(String theme) {
         setConfig("theme", theme);
+    }
+
+    public boolean getFastPassEnabled() {
+        String value = getConfig("use_fastpass");
+        return "true".equalsIgnoreCase(value);
+    }
+
+    public void setFastPassEnabled(boolean enabled) {
+        setConfig("use_fastpass", String.valueOf(enabled));
     }
 
     // Token state methods

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -27,7 +27,6 @@ public class SwingMain extends JFrame {
     private static final Logger logger = LoggerFactory.getLogger(SwingMain.class);
 
     private JComboBox<String> profileComboBox;
-    private JCheckBox useFastPassCheckBox;
     private JButton requestCredentialsButton;
     private JButton showEncryptedButton;
     private JButton showCredentialsButton;
@@ -89,10 +88,6 @@ public class SwingMain extends JFrame {
         requestCredentialsButton = new JButton("Request Credentials");
         requestCredentialsButton.addActionListener(new RequestCredentialsListener());
         profilePanel.add(requestCredentialsButton);
-
-        useFastPassCheckBox = new JCheckBox("Use Okta FastPass");
-        useFastPassCheckBox.setSelected(false);
-        profilePanel.add(useFastPassCheckBox);
 
         showEncryptedButton = new JButton("Encrypted");
         showEncryptedButton.addActionListener(e -> showCredentialsDialog(true, false));
@@ -313,7 +308,7 @@ public class SwingMain extends JFrame {
                 @Override
                 protected Void doInBackground() throws Exception {
                     SamlAuthenticator authenticator = new SamlAuthenticator();
-                    authenticator.requestCredentials(selectedProfile, useFastPassCheckBox.isSelected());
+                    authenticator.requestCredentials(selectedProfile, databaseManager.getFastPassEnabled());
                     return null;
                 }
 
@@ -421,6 +416,8 @@ public class SwingMain extends JFrame {
     }
 
     public static void main(String[] args) {
+        System.setProperty("SE_AVOID_STATS", "true");
+
         SwingUtilities.invokeLater(() -> {
             try {
                 UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());


### PR DESCRIPTION
Moves the FastPass option from the main window into the Configuration dialog so the setting persists across sessions via the SQLite config table (default: disabled). Also disables Selenium Manager's Plausible analytics at startup so users are never opted in to telemetry.