### PR TITLE
Sort profiles alphabetically and exclude global from picker

### DIFF
--- a/src/main/java/com/ourgiant/saml/ConfigManager.java
+++ b/src/main/java/com/ourgiant/saml/ConfigManager.java
@@ -55,11 +55,12 @@ public class ConfigManager {
         Set<String> sections = config.keySet();
 
         for (String section : sections) {
-            if (!section.startsWith("Fed-")) {
+            if (!section.startsWith("Fed-") && !section.equalsIgnoreCase("global")) {
                 profiles.add(section);
             }
         }
 
+        profiles.sort(String.CASE_INSENSITIVE_ORDER);
         return profiles;
     }
 


### PR DESCRIPTION
Profiles in the selection dropdown are now sorted case-insensitively. The 'global' config section is also excluded, as it is an INI metadata section and not a real profile.

Closes #4