### PR TITLE
Add headed browser mode with console sign-in completion

### DIFF
--- a/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
@@ -20,12 +20,19 @@ public class BrowserLoginHandler {
     private final WebDriverWait wait;
     private final boolean useOktaFastPass;
     private final PasswordManager passwordManager;
+    private final boolean showBrowser;
+    private final String accountNumber;
+    private final String iamRole;
 
-    public BrowserLoginHandler(WebDriver driver, boolean useOktaFastPass, PasswordManager passwordManager) {
+    public BrowserLoginHandler(WebDriver driver, boolean useOktaFastPass, PasswordManager passwordManager,
+                                boolean showBrowser, String accountNumber, String iamRole) {
         this.driver = driver;
         this.wait = new WebDriverWait(driver, Duration.ofSeconds(30));
         this.useOktaFastPass = useOktaFastPass;
         this.passwordManager = passwordManager;
+        this.showBrowser = showBrowser;
+        this.accountNumber = accountNumber;
+        this.iamRole = iamRole;
     }
 
     /**
@@ -275,39 +282,77 @@ public class BrowserLoginHandler {
         wait.until(ExpectedConditions.urlContains("signin.aws.amazon.com"));
 
         // Try to find SAML response in form
+        String samlResponse = null;
         try {
             WebElement samlResponseElement = wait.until(
                 ExpectedConditions.presenceOfElementLocated(By.name("SAMLResponse"))
             );
 
-            String samlResponse = samlResponseElement.getAttribute("value");
+            samlResponse = samlResponseElement.getAttribute("value");
             if (samlResponse != null && !samlResponse.isEmpty()) {
                 logger.info("SAML response captured successfully");
-                return samlResponse;
             }
         } catch (TimeoutException e) {
             logger.warn("SAML response element not found, checking page source");
         }
 
         // Fallback: check page source for SAML response
-        String pageSource = driver.getPageSource();
-        if (pageSource.contains("SAMLResponse")) {
-            // Extract SAML response from page source
-            int startIndex = pageSource.indexOf("name=\"SAMLResponse\"");
-            if (startIndex > 0) {
-                int valueStart = pageSource.indexOf("value=\"", startIndex);
-                if (valueStart > 0) {
-                    valueStart += 7; // length of 'value="'
-                    int valueEnd = pageSource.indexOf("\"", valueStart);
-                    if (valueEnd > 0) {
-                        String samlResponse = pageSource.substring(valueStart, valueEnd);
-                        logger.info("SAML response extracted from page source");
-                        return samlResponse;
+        if (samlResponse == null || samlResponse.isEmpty()) {
+            String pageSource = driver.getPageSource();
+            if (pageSource != null && pageSource.contains("SAMLResponse")) {
+                int startIndex = pageSource.indexOf("name=\"SAMLResponse\"");
+                if (startIndex > 0) {
+                    int valueStart = pageSource.indexOf("value=\"", startIndex);
+                    if (valueStart > 0) {
+                        valueStart += 7; // length of 'value="'
+                        int valueEnd = pageSource.indexOf("\"", valueStart);
+                        if (valueEnd > 0) {
+                            samlResponse = pageSource.substring(valueStart, valueEnd);
+                            logger.info("SAML response extracted from page source");
+                        }
                     }
                 }
             }
         }
 
-        throw new RuntimeException("SAML response not found in AWS sign-in page");
+        if (samlResponse == null || samlResponse.isEmpty()) {
+            throw new RuntimeException("SAML response not found in AWS sign-in page");
+        }
+
+        if (showBrowser) {
+            selectRoleAndSignIn();
+        }
+
+        return samlResponse;
+    }
+
+    private void selectRoleAndSignIn() {
+        logger.info("Selecting role {}:{} on AWS SAML page", accountNumber, iamRole);
+
+        driver.manage().window().maximize();
+
+        // Role element ID is the full ARN; match by account number and role name
+        String roleXpath = String.format(
+            "//*[contains(@id, '::%s:') and contains(@id, '%s')]", accountNumber, iamRole
+        );
+
+        try {
+            WebElement roleElement = wait.until(ExpectedConditions.elementToBeClickable(By.xpath(roleXpath)));
+            roleElement.click();
+            logger.info("Role element clicked");
+        } catch (TimeoutException e) {
+            throw new RuntimeException(
+                String.format("Could not find role element for account %s / role %s on AWS SAML page", accountNumber, iamRole), e
+            );
+        }
+
+        // Design A: submit button present; Design B: click was sufficient
+        try {
+            WebElement signInButton = driver.findElement(By.id("signin_button"));
+            signInButton.click();
+            logger.info("Sign-in button clicked");
+        } catch (NoSuchElementException e) {
+            logger.info("No sign-in button found; assuming direct-link design");
+        }
     }
 }

--- a/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
+++ b/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
@@ -7,7 +7,6 @@ import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -15,13 +14,11 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlResponse;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
-import javax.swing.*;
 import java.nio.file.Files;
 import java.io.File;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Duration;
 
 /**
  * Handles SAML authentication and AWS credential generation
@@ -42,7 +39,7 @@ public class SamlAuthenticator {
     /**
      * Main method to request credentials for a profile
      */
-    public void requestCredentials(String profileName, boolean useOktaFastPass) throws Exception {
+    public void requestCredentials(String profileName, boolean useOktaFastPass, boolean showBrowser) throws Exception {
         logger.info("Starting credential request for profile: {}", profileName);
 
         // Get profile configuration
@@ -71,7 +68,7 @@ public class SamlAuthenticator {
         }
 
         // Perform browser login and get SAML response
-        String samlResponse = performBrowserLogin(loginUrl, loginTitle, username, useOktaFastPass);
+        String samlResponse = performBrowserLogin(loginUrl, loginTitle, username, useOktaFastPass, showBrowser, accountNumber, iamRole);
 
         // Parse SAML and get role ARN
         SamlParser samlParser = new SamlParser();
@@ -93,15 +90,20 @@ public class SamlAuthenticator {
     /**
      * Perform browser login and capture SAML response
      */
-    private String performBrowserLogin(String loginUrl, String loginTitle, String username, boolean useOktaFastPass) throws Exception {
+    private String performBrowserLogin(String loginUrl, String loginTitle, String username,
+                                        boolean useOktaFastPass, boolean showBrowser,
+                                        String accountNumber, String iamRole) throws Exception {
         logger.info("Starting browser login to: {}", loginUrl);
 
-        WebDriver driver = createWebDriver();
+        WebDriver driver = createWebDriver(showBrowser);
         try {
-            BrowserLoginHandler loginHandler = new BrowserLoginHandler(driver, useOktaFastPass, passwordManager);
+            BrowserLoginHandler loginHandler = new BrowserLoginHandler(driver, useOktaFastPass, passwordManager, showBrowser, accountNumber, iamRole);
             return loginHandler.performLogin(loginUrl, loginTitle, username);
+        } catch (Exception e) {
+            driver.quit();
+            throw e;
         } finally {
-            if (driver != null) {
+            if (!showBrowser) {
                 driver.quit();
             }
         }
@@ -110,22 +112,24 @@ public class SamlAuthenticator {
     /**
      * Create WebDriver instance based on configuration
      */
-    private WebDriver createWebDriver() {
+    private WebDriver createWebDriver(boolean showBrowser) {
         String browserType = configManager.getBrowserType().toLowerCase();
 
         switch (browserType) {
             case "firefox":
-                return createFirefoxDriver();
+                return createFirefoxDriver(showBrowser);
             case "chrome":
             default:
-                return createChromeDriver();
+                return createChromeDriver(showBrowser);
         }
     }
 
-    private WebDriver createChromeDriver() {
+    private WebDriver createChromeDriver(boolean showBrowser) {
         ChromeOptions options = new ChromeOptions();
         System.setProperty("webdriver.manager.stats", "false");
-        options.addArguments("--headless"); // Run headless
+        if (!showBrowser) {
+            options.addArguments("--headless");
+        }
         options.addArguments("--no-sandbox");
         options.addArguments("--disable-dev-shm-usage");
 
@@ -140,9 +144,11 @@ public class SamlAuthenticator {
         return new ChromeDriver(options);
     }
 
-    private WebDriver createFirefoxDriver() {
+    private WebDriver createFirefoxDriver(boolean showBrowser) {
         FirefoxOptions options = new FirefoxOptions();
-        options.addArguments("--headless");
+        if (!showBrowser) {
+            options.addArguments("--headless");
+        }
         System.setProperty("webdriver.manager.stats", "false");
 
         // Set webdriver.gecko.driver if not set

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -27,6 +27,7 @@ public class SwingMain extends JFrame {
     private static final Logger logger = LoggerFactory.getLogger(SwingMain.class);
 
     private JComboBox<String> profileComboBox;
+    private JCheckBox showBrowserCheckBox;
     private JButton requestCredentialsButton;
     private JButton showEncryptedButton;
     private JButton showCredentialsButton;
@@ -88,6 +89,10 @@ public class SwingMain extends JFrame {
         requestCredentialsButton = new JButton("Request Credentials");
         requestCredentialsButton.addActionListener(new RequestCredentialsListener());
         profilePanel.add(requestCredentialsButton);
+
+        showBrowserCheckBox = new JCheckBox("Show browser");
+        showBrowserCheckBox.setSelected(false);
+        profilePanel.add(showBrowserCheckBox);
 
         showEncryptedButton = new JButton("Encrypted");
         showEncryptedButton.addActionListener(e -> showCredentialsDialog(true, false));
@@ -308,7 +313,7 @@ public class SwingMain extends JFrame {
                 @Override
                 protected Void doInBackground() throws Exception {
                     SamlAuthenticator authenticator = new SamlAuthenticator();
-                    authenticator.requestCredentials(selectedProfile, databaseManager.getFastPassEnabled());
+                    authenticator.requestCredentials(selectedProfile, databaseManager.getFastPassEnabled(), showBrowserCheckBox.isSelected());
                     return null;
                 }
 


### PR DESCRIPTION
Adds a 'Show browser' checkbox (default: headless) to the main window. When checked, the browser runs in headed mode and stays open after credentials are obtained. The AWS SAML role selection page is also completed automatically so the user lands in the correct console account/role rather than being left on the selector page.

Supports both AWS SAML page designs: radio-button+signin_button (A) and direct hyperlink (B). Also removes stale unused imports from SamlAuthenticator.

Closes #3