### PR TITLE
Add granular status bar messaging during credential retrieval (issue #18)

### DIFF
--- a/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.time.Duration;
+import java.util.function.Consumer;
 
 /**
  * Handles browser automation for SAML login
@@ -23,9 +24,11 @@ public class BrowserLoginHandler {
     private final boolean showBrowser;
     private final String accountNumber;
     private final String iamRole;
+    private final Consumer<String> statusCallback;
 
     public BrowserLoginHandler(WebDriver driver, boolean useOktaFastPass, PasswordManager passwordManager,
-                                boolean showBrowser, String accountNumber, String iamRole) {
+                                boolean showBrowser, String accountNumber, String iamRole,
+                                Consumer<String> statusCallback) {
         this.driver = driver;
         this.wait = new WebDriverWait(driver, Duration.ofSeconds(30));
         this.useOktaFastPass = useOktaFastPass;
@@ -33,6 +36,7 @@ public class BrowserLoginHandler {
         this.showBrowser = showBrowser;
         this.accountNumber = accountNumber;
         this.iamRole = iamRole;
+        this.statusCallback = statusCallback;
     }
 
     /**
@@ -42,13 +46,12 @@ public class BrowserLoginHandler {
         logger.info("Navigating to login page: {}", loginUrl);
 
         try {
-            // Navigate to login page
+            statusCallback.accept("Navigating to login page: " + loginUrl + "...");
             driver.get(loginUrl);
 
-            // Wait for login page to load
+            statusCallback.accept("Waiting for login page to load...");
             wait.until(ExpectedConditions.titleContains(loginTitle));
 
-            // Handle Okta login (since user specified Okta)
             return handleOktaLogin(username);
 
         } catch (Exception e) {
@@ -64,46 +67,49 @@ public class BrowserLoginHandler {
         logger.info("Handling Okta login for user: {}", username);
 
         // Detect managed-device Okta flow with pre-authenticated MFA screen first
+        statusCallback.accept("Checking for pre-authenticated Okta MFA screen...");
         if (isPreAuthenticatedOktaMfaScreen()) {
             logger.info("Detected pre-authenticated Okta MFA screen; skipping username/password entry");
+            statusCallback.accept("Pre-authenticated MFA screen detected; selecting MFA method...");
             clickOktaSelection();
             return waitForSamlResponse();
         }
 
         // Wait for and fill username field
         try {
+            statusCallback.accept("Entering username: " + username + "...");
             WebElement usernameField = wait.until(ExpectedConditions.elementToBeClickable(By.name("identifier")));
             usernameField.clear();
             usernameField.sendKeys(username);
 
-            // Click next/sign in
-            // <input class="button button-primary" type="submit" value="Next" data-type="save">
             WebElement nextButton = wait.until(ExpectedConditions.elementToBeClickable(By.className("button-primary")));
             nextButton.click();
         } catch (TimeoutException e) {
             logger.info("Okta username field not found; checking for managed-device MFA flow");
+            statusCallback.accept("Username field not found; checking for managed-device MFA flow...");
             if (isPreAuthenticatedOktaMfaScreen()) {
                 logger.info("Detected managed-device Okta MFA flow after missing username field");
+                statusCallback.accept("Managed-device MFA flow detected; selecting MFA method...");
                 clickOktaSelection();
                 return waitForSamlResponse();
             }
             throw e;
         }
-        // Check for interstitial page that may require clicking through before password entry
 
-        logger.info("Checking for intermediate verification page");
+        statusCallback.accept("Checking for intermediate verification page...");
         if (isIntermediateVerifificationPage()) {
             logger.info("Handling intermediate verification page");
+            statusCallback.accept("Intermediate verification page detected; switching to password entry...");
             clickUsePassword();
         }
 
         try {
             WebElement passwordField = wait.until(ExpectedConditions.elementToBeClickable(By.name("credentials.passcode")));
+            statusCallback.accept("Entering password...");
             String password = promptForPassword();
             passwordField.clear();
             passwordField.sendKeys(password);
 
-            // Submit password
             WebElement signInButton = wait.until(ExpectedConditions.elementToBeClickable(By.className("button-primary")));
             signInButton.click();
 
@@ -113,12 +119,13 @@ public class BrowserLoginHandler {
         }
 
         if (useOktaFastPass) {
+            statusCallback.accept("Selecting Okta FastPass...");
             clickOktaFastPassSelection();
         } else {
+            statusCallback.accept("Sending Okta MFA push — check your device for an approval request...");
             clickOktaMfaSelection();
         }
 
-        // Wait for SAML response or AWS sign-in page
         return waitForSamlResponse();
     }
 
@@ -278,8 +285,10 @@ public class BrowserLoginHandler {
     private String waitForSamlResponse() throws Exception {
         logger.info("Waiting for SAML response...");
 
-        // Wait for redirect to AWS sign-in page
+        statusCallback.accept("Waiting for redirect to AWS sign-in page...");
         wait.until(ExpectedConditions.urlContains("signin.aws.amazon.com"));
+
+        statusCallback.accept("Capturing SAML response...");
 
         // Try to find SAML response in form
         String samlResponse = null;
@@ -328,6 +337,7 @@ public class BrowserLoginHandler {
 
     private void selectRoleAndSignIn() {
         logger.info("Selecting role {}:{} on AWS SAML page", accountNumber, iamRole);
+        statusCallback.accept("Selecting AWS role " + iamRole + " on AWS console...");
 
         driver.manage().window().maximize();
 

--- a/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
+++ b/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.function.Consumer;
 
 /**
  * Handles SAML authentication and AWS credential generation
@@ -39,8 +40,10 @@ public class SamlAuthenticator {
     /**
      * Main method to request credentials for a profile
      */
-    public void requestCredentials(String profileName, boolean useOktaFastPass, boolean showBrowser) throws Exception {
+    public void requestCredentials(String profileName, boolean useOktaFastPass, boolean showBrowser,
+                                   Consumer<String> statusCallback) throws Exception {
         logger.info("Starting credential request for profile: {}", profileName);
+        statusCallback.accept("Loading configuration for profile: " + profileName + "...");
 
         // Get profile configuration
         String samlProvider = configManager.getSamlProvider(profileName);
@@ -68,20 +71,25 @@ public class SamlAuthenticator {
         }
 
         // Perform browser login and get SAML response
-        String samlResponse = performBrowserLogin(loginUrl, loginTitle, username, useOktaFastPass, showBrowser, accountNumber, iamRole);
+        String samlResponse = performBrowserLogin(loginUrl, loginTitle, username, useOktaFastPass, showBrowser,
+                accountNumber, iamRole, statusCallback);
 
         // Parse SAML and get role ARN
+        statusCallback.accept("Parsing SAML response...");
         SamlParser samlParser = new SamlParser();
         var roles = samlParser.parseRolesFromSaml(samlResponse);
 
         // Find the matching role
+        statusCallback.accept("Locating AWS role: " + iamRole + "...");
         String roleArn = findMatchingRole(roles, accountNumber, iamRole);
         String principalArn = "arn:aws:iam::" + accountNumber + ":saml-provider/" + samlProvider.substring(4); // Remove "Fed-" prefix
 
         // Assume role with SAML
+        statusCallback.accept("Assuming role with AWS STS...");
         var awsCredentials = assumeRoleWithSaml(principalArn, roleArn, samlResponse, awsRegion, sessionDuration);
 
         // Save credentials
+        statusCallback.accept("Saving credentials for profile: " + profileName + "...");
         credentialManager.saveCredentials(profileName, awsCredentials);
 
         logger.info("Successfully obtained and saved credentials for profile: {}", profileName);
@@ -92,12 +100,15 @@ public class SamlAuthenticator {
      */
     private String performBrowserLogin(String loginUrl, String loginTitle, String username,
                                         boolean useOktaFastPass, boolean showBrowser,
-                                        String accountNumber, String iamRole) throws Exception {
+                                        String accountNumber, String iamRole,
+                                        Consumer<String> statusCallback) throws Exception {
         logger.info("Starting browser login to: {}", loginUrl);
+        statusCallback.accept("Launching browser...");
 
         WebDriver driver = createWebDriver(showBrowser);
         try {
-            BrowserLoginHandler loginHandler = new BrowserLoginHandler(driver, useOktaFastPass, passwordManager, showBrowser, accountNumber, iamRole);
+            BrowserLoginHandler loginHandler = new BrowserLoginHandler(driver, useOktaFastPass, passwordManager,
+                    showBrowser, accountNumber, iamRole, statusCallback);
             return loginHandler.performLogin(loginUrl, loginTitle, username);
         } catch (Exception e) {
             driver.quit();

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -346,13 +346,19 @@ public class SwingMain extends JFrame {
             // Disable button during processing
             requestCredentialsButton.setEnabled(false);
             requestCredentialsButton.setText("Requesting...");
+            statusLabel.setText("Starting credential request for profile: " + selectedProfile + "...");
 
             // Run credential request in background thread
             SwingWorker<Void, Void> worker = new SwingWorker<Void, Void>() {
                 @Override
                 protected Void doInBackground() throws Exception {
                     SamlAuthenticator authenticator = new SamlAuthenticator();
-                    authenticator.requestCredentials(selectedProfile, databaseManager.getFastPassEnabled(), showBrowserCheckBox.isSelected());
+                    authenticator.requestCredentials(
+                        selectedProfile,
+                        databaseManager.getFastPassEnabled(),
+                        showBrowserCheckBox.isSelected(),
+                        msg -> SwingUtilities.invokeLater(() -> statusLabel.setText(msg))
+                    );
                     return null;
                 }
 


### PR DESCRIPTION
## Summary

- Threads a `Consumer<String>` status callback from `SwingMain` through `SamlAuthenticator` and `BrowserLoginHandler`
- Emits step-by-step progress to the status bar at each phase of the login flow (browser launch, username entry, password entry, MFA, SAML capture, STS role assumption, credential save)
- Includes an explicit prompt when an Okta MFA push is sent: "Sending Okta MFA push — check your device for an approval request..."

## Test plan

- [ ] Request credentials for a profile and verify status bar updates through each phase
- [ ] Verify MFA push message appears when Okta push is triggered
- [ ] Verify FastPass path shows "Selecting Okta FastPass..." instead of MFA push message
- [ ] Verify pre-authenticated MFA screen path shows correct status messages
- [ ] Verify success and failure dialogs still appear as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)