### PR TITLE
Bump version to 1.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -174,7 +174,7 @@ public class SwingMain extends JFrame {
     private void showAboutDialog() {
         String version = getClass().getPackage() != null ? getClass().getPackage().getImplementationVersion() : null;
         if (version == null) {
-            version = "1.0.7";
+            version = "1.0.8";
         }
 
         JPanel panel = new JPanel();


### PR DESCRIPTION
## Summary

- Bumps `pom.xml` version from `1.0.7` to `1.0.8`
- Updates fallback version string in About dialog to match

## Changes since 1.0.7

- #17 — About menu item
- #18 — Granular status bar messaging during credential retrieval
- #22 — First-run setup dialog for new environments (with stale database cleanup and antialiasing fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)