### PR TITLE
Add nightly build workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,47 @@
+name: Nightly Build
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 24
+        uses: actions/setup-java@v4
+        with:
+          java-version: '24'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn package -q
+
+      - name: Delete existing nightly release
+        run: gh release delete nightly --yes --cleanup-tag || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create nightly release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: Nightly Build
+          prerelease: true
+          files: target/aws-idp-saml-ui-all.jar
+          body: |
+            Automated nightly build from `main` — ${{ github.sha }}
+
+            **Requirements:** Java 24 or later
+
+            **Run with:**
+            ```
+            java -jar aws-idp-saml-ui-all.jar
+            ```


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/nightly.yml` that runs on a cron schedule (midnight UTC daily) and on manual `workflow_dispatch`
- Builds the fat JAR with Maven and publishes it as a rolling pre-release tagged `nightly`
- Each run deletes and recreates the `nightly` release so only the latest build is available
- Uses `ubuntu-latest` (no installer needed — users run `java -jar`)

## Test plan
- [ ] Trigger manually via Actions > Nightly Build > Run workflow and verify the `nightly` pre-release appears with `aws-idp-saml-ui-all.jar` attached
- [ ] Trigger a second time and verify the previous release is replaced, not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)