### PR TITLE
Fix session duration precedence to prefer UI config over samlsts (issue #31)

### DIFF
--- a/src/main/java/com/ourgiant/saml/ConfigManager.java
+++ b/src/main/java/com/ourgiant/saml/ConfigManager.java
@@ -209,19 +209,13 @@ public class ConfigManager {
      * Get session duration for a profile
      */
     public int getSessionDuration(String profileName) {
-        Profile.Section profile = getProfile(profileName);
-        if (profile != null) {
-            String duration = profile.get("sessionduration");
-            if (duration != null) {
-                try {
-                    return Integer.parseInt(duration);
-                } catch (NumberFormatException e) {
-                    logger.warn("Invalid session duration for profile {}: {}", profileName, duration);
-                }
-            }
+        // 1. UI database value takes highest priority
+        int dbDuration = databaseManager.getSessionDuration();
+        if (dbDuration > 0) {
+            return dbDuration;
         }
 
-        // Fall back to global config
+        // 2. Global samlsts config
         Profile.Section global = getGlobalConfig();
         if (global != null) {
             String duration = global.get("sessionduration");
@@ -234,7 +228,20 @@ public class ConfigManager {
             }
         }
 
-        return databaseManager.getSessionDuration(); // Use database default (4 hours)
+        // 3. Profile-specific samlsts config
+        Profile.Section profile = getProfile(profileName);
+        if (profile != null) {
+            String duration = profile.get("sessionduration");
+            if (duration != null) {
+                try {
+                    return Integer.parseInt(duration);
+                } catch (NumberFormatException e) {
+                    logger.warn("Invalid session duration for profile {}: {}", profileName, duration);
+                }
+            }
+        }
+
+        return 14400;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fixes `ConfigManager.getSessionDuration()` to use the correct precedence order
- Previously the samlsts global config was overriding the UI-configured value

## Precedence (new)
1. UI database value (highest)
2. samlsts `[global]` section
3. samlsts profile-specific section

## Test plan
- [ ] Set a session duration in Configuration dialog, confirm it is used even when `sessionduration` is set in samlsts `[global]`
- [ ] Remove UI setting (or reset to 0), confirm samlsts global value is picked up
- [ ] Remove both UI and global values, confirm profile-specific value is used

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)