### PR TITLE
Include built JAR in release artifacts (issue #38)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,5 +57,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ github.ref_name }}
-          files: AWS-IDP-SAML-${{ steps.version.outputs.version }}.zip
+          files: |
+            AWS-IDP-SAML-${{ steps.version.outputs.version }}.zip
+            target/aws-idp-saml-ui-all.jar
           generate_release_notes: true


### PR DESCRIPTION
## Summary

- Adds `aws-idp-saml-ui-all.jar` to the `files:` list in the `Create GitHub Release` step of `build.yml`
- Tagged releases now ship both the Windows app-image ZIP and the standalone JAR, matching what the nightly workflow already provides
- No changes to the jpackage/ZIP flow

Closes #38

## Test plan

- [ ] Tag a release and confirm both `AWS-IDP-SAML-<version>.zip` and `aws-idp-saml-ui-all.jar` appear as release assets
- [ ] Verify existing Windows ZIP artifact is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)