### PR TITLE
Derive About dialog version fallback from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>
@@ -98,6 +98,22 @@
 
     <build>
         <finalName>aws-idp-saml-ui</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>version.properties</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>version.properties</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -14,8 +14,11 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -182,11 +185,7 @@ public class SwingMain extends JFrame {
     }
 
     private void showAboutDialog() {
-        String version = getClass().getPackage() != null ? getClass().getPackage().getImplementationVersion() : null;
-        if (version == null) {
-            version = "1.0.8";
-        }
-        final String currentVersion = version;
+        final String currentVersion = resolveCurrentVersion();
 
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -265,6 +264,27 @@ public class SwingMain extends JFrame {
         versionChecker.execute();
 
         JOptionPane.showMessageDialog(this, panel, "About AWS IDP SAML UI", JOptionPane.PLAIN_MESSAGE);
+    }
+
+    private String resolveCurrentVersion() {
+        String version = getClass().getPackage() != null ? getClass().getPackage().getImplementationVersion() : null;
+        if (version == null) {
+            version = readVersionFromPropertiesResource();
+        }
+        return version != null ? version : "unknown";
+    }
+
+    private String readVersionFromPropertiesResource() {
+        try (InputStream in = getClass().getResourceAsStream("/version.properties")) {
+            if (in != null) {
+                Properties props = new Properties();
+                props.load(in);
+                return props.getProperty("version");
+            }
+        } catch (IOException e) {
+            logger.debug("Could not read version.properties", e);
+        }
+        return null;
     }
 
     private String[] fetchLatestRelease() {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}


### PR DESCRIPTION
## Summary
- The About dialog's version fallback (used when the JAR manifest's `Implementation-Version` isn't present, e.g. running unpackaged) was a hardcoded string that a developer had to remember to bump every release — it had already drifted to `1.0.8` while `pom.xml` was at `1.0.10`.
- Added `src/main/resources/version.properties` containing `version=${project.version}`, filtered by Maven at build time so `pom.xml` is the single source of truth.
- `SwingMain.resolveCurrentVersion()` now falls back to reading that properties file instead of a second hardcoded literal.

Fixes #43

## Test plan
- [x] `mvn compile` — confirmed `target/classes/version.properties` renders `version=1.0.10`, matching `pom.xml`
- [x] `mvn test` — all tests pass