### PR TITLE
Restrict SQLite DB and credentials file to owner-only permissions

### DIFF
--- a/src/main/java/com/ourgiant/saml/CredentialManager.java
+++ b/src/main/java/com/ourgiant/saml/CredentialManager.java
@@ -183,6 +183,7 @@ public class CredentialManager {
             }
 
             credentials.store(credFile);
+            FilePermissions.restrictToOwner(credFile.toPath());
             logger.info("Credentials saved for profile: {}", profileName);
         } catch (Exception e) {
             logger.error("Failed to save credentials for profile: {}", profileName, e);

--- a/src/main/java/com/ourgiant/saml/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/DatabaseManager.java
@@ -36,6 +36,7 @@ public class DatabaseManager {
 
             connection = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
             createTables();
+            FilePermissions.restrictToOwner(new File(dbPath).toPath());
             logger.info("Database initialized at: {}", dbPath);
         } catch (SQLException e) {
             logger.error("Failed to initialize database", e);

--- a/src/main/java/com/ourgiant/saml/FilePermissions.java
+++ b/src/main/java/com/ourgiant/saml/FilePermissions.java
@@ -1,0 +1,37 @@
+package com.ourgiant.saml;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+/**
+ * Restricts sensitive files (credentials, encrypted-password database) to owner-only access,
+ * matching the AWS CLI's handling of ~/.aws/credentials.
+ */
+final class FilePermissions {
+    private static final Logger logger = LoggerFactory.getLogger(FilePermissions.class);
+
+    private FilePermissions() {
+    }
+
+    static void restrictToOwner(Path path) {
+        try {
+            if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rw-------"));
+            } else {
+                File file = path.toFile();
+                file.setReadable(false, false);
+                file.setWritable(false, false);
+                file.setReadable(true, true);
+                file.setWritable(true, true);
+            }
+        } catch (IOException | UnsupportedOperationException e) {
+            logger.warn("Could not restrict permissions on file: {}", path, e);
+        }
+    }
+}

--- a/src/test/java/com/ourgiant/saml/FilePermissionsTest.java
+++ b/src/test/java/com/ourgiant/saml/FilePermissionsTest.java
@@ -1,0 +1,27 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class FilePermissionsTest {
+
+    @Test
+    void restrictToOwner_setsOwnerOnlyReadWriteOnPosix(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("sensitive.db");
+        Files.writeString(file, "secret");
+        assumeTrue(file.getFileSystem().supportedFileAttributeViews().contains("posix"));
+
+        FilePermissions.restrictToOwner(file);
+
+        Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(file);
+        assertEquals(Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE), permissions);
+    }
+}


### PR DESCRIPTION
## Summary
- Neither the SQLite DB (`~/.aws/aws_saml.db` — holds the AES encryption key, encrypted Okta password, and settings) nor `~/.aws/credentials` restricted file permissions at creation, unlike the AWS CLI which chmod's `credentials` to owner-only.
- Added `FilePermissions.restrictToOwner(Path)` — uses POSIX permissions (`rw-------`) where supported, falls back to the legacy `File.setReadable/setWritable` owner-only trick on Windows.
- Wired into `DatabaseManager.initializeDatabase()` and `CredentialManager.saveCredentials()`, applied on every init/save (not just first creation) so existing installations get hardened retroactively, not just new ones.

Fixes #46

**Stacked on #48** (this branch is based on `feature/45-test-foundation` since it needs the JUnit/Mockito setup added there) — should merge after that PR, targeting `main` at that point.

## Test plan
- [x] `mvn test` — 25/25 pass, including new `FilePermissionsTest` (verifies `rw-------` via `@TempDir`)
- [x] Manual end-to-end check: pointed `user.home` at a scratch directory, ran the real `DatabaseManager`/`CredentialManager` code paths, confirmed both the DB file and `credentials` file came out as `[OWNER_READ, OWNER_WRITE]`