### PR TITLE
Merge file-permission hardening into main

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,26 @@
             <artifactId>flatlaf-intellij-themes</artifactId>
             <version>3.4.1</version>
         </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.15.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.15.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -124,6 +144,12 @@
                     <target>24</target>
                     <release>24</release>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
             </plugin>
 
             <plugin>

--- a/src/main/java/com/ourgiant/saml/CredentialManager.java
+++ b/src/main/java/com/ourgiant/saml/CredentialManager.java
@@ -183,6 +183,7 @@ public class CredentialManager {
             }
 
             credentials.store(credFile);
+            FilePermissions.restrictToOwner(credFile.toPath());
             logger.info("Credentials saved for profile: {}", profileName);
         } catch (Exception e) {
             logger.error("Failed to save credentials for profile: {}", profileName, e);

--- a/src/main/java/com/ourgiant/saml/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/DatabaseManager.java
@@ -36,6 +36,7 @@ public class DatabaseManager {
 
             connection = DriverManager.getConnection("jdbc:sqlite:" + dbPath);
             createTables();
+            FilePermissions.restrictToOwner(new File(dbPath).toPath());
             logger.info("Database initialized at: {}", dbPath);
         } catch (SQLException e) {
             logger.error("Failed to initialize database", e);

--- a/src/main/java/com/ourgiant/saml/FilePermissions.java
+++ b/src/main/java/com/ourgiant/saml/FilePermissions.java
@@ -1,0 +1,37 @@
+package com.ourgiant.saml;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+
+/**
+ * Restricts sensitive files (credentials, encrypted-password database) to owner-only access,
+ * matching the AWS CLI's handling of ~/.aws/credentials.
+ */
+final class FilePermissions {
+    private static final Logger logger = LoggerFactory.getLogger(FilePermissions.class);
+
+    private FilePermissions() {
+    }
+
+    static void restrictToOwner(Path path) {
+        try {
+            if (path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+                Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rw-------"));
+            } else {
+                File file = path.toFile();
+                file.setReadable(false, false);
+                file.setWritable(false, false);
+                file.setReadable(true, true);
+                file.setWritable(true, true);
+            }
+        } catch (IOException | UnsupportedOperationException e) {
+            logger.warn("Could not restrict permissions on file: {}", path, e);
+        }
+    }
+}

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -314,7 +314,7 @@ public class SwingMain extends JFrame {
         return null;
     }
 
-    private String extractJsonString(String json, String key) {
+    static String extractJsonString(String json, String key) {
         String search = "\"" + key + "\":\"";
         int start = json.indexOf(search);
         if (start == -1) return null;
@@ -324,7 +324,7 @@ public class SwingMain extends JFrame {
         return json.substring(start, end);
     }
 
-    private boolean isNewerVersion(String latest, String current) {
+    static boolean isNewerVersion(String latest, String current) {
         try {
             String[] latestParts = latest.split("\\.");
             String[] currentParts = current.split("\\.");

--- a/src/test/java/com/ourgiant/saml/FilePermissionsTest.java
+++ b/src/test/java/com/ourgiant/saml/FilePermissionsTest.java
@@ -1,0 +1,27 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+class FilePermissionsTest {
+
+    @Test
+    void restrictToOwner_setsOwnerOnlyReadWriteOnPosix(@TempDir Path tempDir) throws Exception {
+        Path file = tempDir.resolve("sensitive.db");
+        Files.writeString(file, "secret");
+        assumeTrue(file.getFileSystem().supportedFileAttributeViews().contains("posix"));
+
+        FilePermissions.restrictToOwner(file);
+
+        Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(file);
+        assertEquals(Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE), permissions);
+    }
+}

--- a/src/test/java/com/ourgiant/saml/PasswordManagerTest.java
+++ b/src/test/java/com/ourgiant/saml/PasswordManagerTest.java
@@ -1,0 +1,97 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordManagerTest {
+
+    @Mock
+    private DatabaseManager databaseManager;
+
+    private final Map<String, String> config = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        config.clear();
+        when(databaseManager.getConfig(anyString())).thenAnswer(inv -> config.get(inv.getArgument(0, String.class)));
+        doAnswer(inv -> config.put(inv.getArgument(0, String.class), inv.getArgument(1, String.class)))
+                .when(databaseManager).setConfig(anyString(), anyString());
+        lenient().when(databaseManager.getPasswordExpirationMinutes()).thenReturn(1440);
+    }
+
+    @Test
+    void storeAndRetrievePassword_roundTripsCorrectly() {
+        PasswordManager passwordManager = new PasswordManager(databaseManager);
+
+        passwordManager.storePassword("hunter2");
+
+        assertEquals("hunter2", passwordManager.retrievePassword());
+    }
+
+    @Test
+    void storedPassword_isNotKeptAsPlaintextInConfig() {
+        PasswordManager passwordManager = new PasswordManager(databaseManager);
+
+        passwordManager.storePassword("hunter2");
+
+        assertEquals(false, config.get("okta_password").contains("hunter2"));
+    }
+
+    @Test
+    void retrievePassword_returnsNullWhenNothingStored() {
+        PasswordManager passwordManager = new PasswordManager(databaseManager);
+
+        assertNull(passwordManager.retrievePassword());
+    }
+
+    @Test
+    void retrievePassword_returnsNullAndClearsWhenExpired() {
+        when(databaseManager.getPasswordExpirationMinutes()).thenReturn(0);
+        PasswordManager passwordManager = new PasswordManager(databaseManager);
+        passwordManager.storePassword("hunter2");
+
+        assertNull(passwordManager.retrievePassword());
+        assertEquals("", config.get("okta_password"));
+    }
+
+    @Test
+    void clearPassword_removesStoredPassword() {
+        PasswordManager passwordManager = new PasswordManager(databaseManager);
+        passwordManager.storePassword("hunter2");
+
+        passwordManager.clearPassword();
+
+        assertNull(passwordManager.retrievePassword());
+    }
+
+    @Test
+    void isPasswordStorageEnabled_defaultsToFalse() {
+        PasswordManager passwordManager = new PasswordManager(databaseManager);
+
+        assertEquals(false, passwordManager.isPasswordStorageEnabled());
+    }
+
+    @Test
+    void setPasswordStorageEnabled_falseClearsStoredPassword() {
+        PasswordManager passwordManager = new PasswordManager(databaseManager);
+        passwordManager.storePassword("hunter2");
+
+        passwordManager.setPasswordStorageEnabled(false);
+
+        assertNull(passwordManager.retrievePassword());
+    }
+}

--- a/src/test/java/com/ourgiant/saml/SamlParserTest.java
+++ b/src/test/java/com/ourgiant/saml/SamlParserTest.java
@@ -1,0 +1,86 @@
+package com.ourgiant.saml;
+
+import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SamlParserTest {
+
+    private final SamlParser parser = new SamlParser();
+
+    @Test
+    void parseRolesFromSaml_extractsRolesFromAttributeValues() throws Exception {
+        String saml = samlWithRoleAttributeValues(
+                "arn:aws:iam::123456789012:role/AdminRole,arn:aws:iam::123456789012:saml-provider/Okta",
+                "arn:aws:iam::987654321098:role/ReadOnlyRole,arn:aws:iam::987654321098:saml-provider/Okta"
+        );
+
+        List<SamlRole> roles = parser.parseRolesFromSaml(encode(saml));
+
+        assertEquals(2, roles.size());
+        assertEquals("123456789012", roles.get(0).getAccountNumber());
+        assertEquals("AdminRole", roles.get(0).getRoleName());
+        assertEquals("987654321098", roles.get(1).getAccountNumber());
+        assertEquals("ReadOnlyRole", roles.get(1).getRoleName());
+    }
+
+    @Test
+    void parseRolesFromSaml_ignoresNonRoleAttributes() throws Exception {
+        String saml = """
+                <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+                  <saml:Assertion>
+                    <saml:AttributeStatement>
+                      <saml:Attribute Name="https://aws.amazon.com/SAML/Attributes/SessionDuration">
+                        <saml:AttributeValue>3600</saml:AttributeValue>
+                      </saml:Attribute>
+                    </saml:AttributeStatement>
+                  </saml:Assertion>
+                </samlp:Response>
+                """;
+
+        List<SamlRole> roles = parser.parseRolesFromSaml(encode(saml));
+
+        assertTrue(roles.isEmpty());
+    }
+
+    @Test
+    void parseRolesFromSaml_throwsWhenAssertionMissing() {
+        String saml = """
+                <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+                </samlp:Response>
+                """;
+
+        assertThrows(Exception.class, () -> parser.parseRolesFromSaml(encode(saml)));
+    }
+
+    private static String samlWithRoleAttributeValues(String... roleValues) {
+        StringBuilder valuesXml = new StringBuilder();
+        for (String value : roleValues) {
+            valuesXml.append("<saml:AttributeValue>").append(value).append("</saml:AttributeValue>\n");
+        }
+
+        return """
+                <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+                  <saml:Assertion>
+                    <saml:AttributeStatement>
+                      <saml:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">
+                        %s
+                      </saml:Attribute>
+                    </saml:AttributeStatement>
+                  </saml:Assertion>
+                </samlp:Response>
+                """.formatted(valuesXml);
+    }
+
+    private static String encode(String xml) {
+        return Base64.encodeBase64String(xml.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/com/ourgiant/saml/SwingMainVersionComparisonTest.java
+++ b/src/test/java/com/ourgiant/saml/SwingMainVersionComparisonTest.java
@@ -1,0 +1,58 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SwingMainVersionComparisonTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "1.0.10, 1.0.9",
+            "1.1.0, 1.0.9",
+            "2.0.0, 1.9.9",
+            "1.0.10, 1.0.2",
+            "1.0.0.1, 1.0.0"
+    })
+    void isNewerVersion_returnsTrueWhenLatestIsGreater(String latest, String current) {
+        assertTrue(SwingMain.isNewerVersion(latest, current));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "1.0.9, 1.0.9",
+            "1.0.9, 1.0.10",
+            "1.0.9, 1.1.0",
+            "1.9.9, 2.0.0",
+            "1.0.0, 1.0.0.1"
+    })
+    void isNewerVersion_returnsFalseWhenLatestIsNotGreater(String latest, String current) {
+        assertFalse(SwingMain.isNewerVersion(latest, current));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "not-a-version, 1.0.9",
+            "1.0.9, not-a-version"
+    })
+    void isNewerVersion_returnsFalseOnUnparsableInput(String latest, String current) {
+        assertFalse(SwingMain.isNewerVersion(latest, current));
+    }
+
+    @Test
+    void extractJsonString_findsValueForKey() {
+        String json = "{\"tag_name\":\"v1.0.10\",\"html_url\":\"https://example.com/releases/v1.0.10\"}";
+        assertEquals("v1.0.10", SwingMain.extractJsonString(json, "tag_name"));
+        assertEquals("https://example.com/releases/v1.0.10", SwingMain.extractJsonString(json, "html_url"));
+    }
+
+    @Test
+    void extractJsonString_returnsNullWhenKeyMissing() {
+        assertNull(SwingMain.extractJsonString("{\"other_key\":\"value\"}", "tag_name"));
+    }
+}


### PR DESCRIPTION
## Summary
PR #49 (file-permission hardening, issue #46) was stacked on and merged into `feature/45-test-foundation` rather than `main`. #48 had already merged into `main` by that point, so `main` never picked up #49's commit. This PR forwards that one remaining commit (`3b77e59`) into `main`.

Fixes #46