### PR TITLE
Add browser selection (Chrome/Firefox) to Settings dialog

### DIFF
--- a/src/main/java/com/ourgiant/saml/ConfigManager.java
+++ b/src/main/java/com/ourgiant/saml/ConfigManager.java
@@ -259,13 +259,21 @@ public class ConfigManager {
     }
 
     /**
-     * Get browser type from global config
+     * Get browser type to use for SAML login
      */
     public String getBrowserType() {
+        // 1. UI database value takes highest priority, if the user has explicitly set one
+        String dbBrowser = databaseManager.getConfig("browser");
+        if (dbBrowser != null && !dbBrowser.isEmpty()) {
+            return dbBrowser;
+        }
+
+        // 2. Global samlsts config, set during first-run setup
         Profile.Section global = getGlobalConfig();
         if (global != null) {
             return global.get("browser", "chrome");
         }
+
         return "chrome";
     }
 

--- a/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
+++ b/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
@@ -14,6 +14,9 @@ import java.awt.event.ActionListener;
 public class ConfigurationDialog extends JDialog {
     private static final Logger logger = LoggerFactory.getLogger(ConfigurationDialog.class);
 
+    private static final String[] BROWSERS = {"chrome", "firefox"};
+
+    private final ConfigManager configManager;
     private final DatabaseManager databaseManager;
     private final PasswordManager passwordManager;
     private JSpinner durationSpinner;
@@ -21,12 +24,14 @@ public class ConfigurationDialog extends JDialog {
     private JButton forgetPasswordButton;
     private JSpinner passwordExpirationSpinner;
     private JComboBox<String> themeComboBox;
+    private JComboBox<String> browserComboBox;
     private JCheckBox useFastPassCheckBox;
     private JButton saveButton;
     private JButton cancelButton;
 
-    public ConfigurationDialog(Frame parent, DatabaseManager databaseManager, PasswordManager passwordManager) {
+    public ConfigurationDialog(Frame parent, ConfigManager configManager, DatabaseManager databaseManager, PasswordManager passwordManager) {
         super(parent, "Configuration", true);
+        this.configManager = configManager;
         this.databaseManager = databaseManager;
         this.passwordManager = passwordManager;
 
@@ -51,7 +56,8 @@ public class ConfigurationDialog extends JDialog {
         outerGbc.gridy = 0; outerPanel.add(buildSessionSection(), outerGbc);
         outerGbc.gridy = 1; outerPanel.add(buildPasswordSection(), outerGbc);
         outerGbc.gridy = 2; outerPanel.add(buildAppearanceSection(), outerGbc);
-        outerGbc.gridy = 3; outerPanel.add(buildAuthSection(), outerGbc);
+        outerGbc.gridy = 3; outerPanel.add(buildBrowserSection(), outerGbc);
+        outerGbc.gridy = 4; outerPanel.add(buildAuthSection(), outerGbc);
 
         add(outerPanel, BorderLayout.CENTER);
 
@@ -131,6 +137,20 @@ public class ConfigurationDialog extends JDialog {
         return panel;
     }
 
+    private JPanel buildBrowserSection() {
+        JPanel panel = titledPanel("Browser");
+        GridBagConstraints gbc = sectionGbc();
+
+        gbc.gridx = 0; gbc.gridy = 0;
+        panel.add(new JLabel("Browser:"), gbc);
+
+        gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
+        browserComboBox = new JComboBox<>(BROWSERS);
+        panel.add(browserComboBox, gbc);
+
+        return panel;
+    }
+
     private JPanel buildAuthSection() {
         JPanel panel = titledPanel("Authentication");
         GridBagConstraints gbc = sectionGbc();
@@ -191,6 +211,8 @@ public class ConfigurationDialog extends JDialog {
 
         themeComboBox.setSelectedItem(databaseManager.getTheme());
 
+        browserComboBox.setSelectedItem(configManager.getBrowserType());
+
         useFastPassCheckBox.setSelected(databaseManager.getFastPassEnabled());
 
         updatePasswordExpirationEnabled();
@@ -213,11 +235,14 @@ public class ConfigurationDialog extends JDialog {
                 String selectedTheme = (String) themeComboBox.getSelectedItem();
                 databaseManager.setTheme(selectedTheme);
 
+                String selectedBrowser = (String) browserComboBox.getSelectedItem();
+                databaseManager.setBrowser(selectedBrowser);
+
                 boolean useFastPass = useFastPassCheckBox.isSelected();
                 databaseManager.setFastPassEnabled(useFastPass);
 
-                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, use_fastpass = {}",
-                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, useFastPass);
+                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, browser = {}, use_fastpass = {}",
+                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, selectedBrowser, useFastPass);
 
                 // Apply theme immediately
                 if (ThemeManager.applyTheme(selectedTheme)) {

--- a/src/main/java/com/ourgiant/saml/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/DatabaseManager.java
@@ -163,6 +163,18 @@ public class DatabaseManager {
         setConfig("use_fastpass", String.valueOf(enabled));
     }
 
+    // Intentionally not seeded in insertDefaultConfig(): an absent value lets
+    // ConfigManager.getBrowserType() fall back to the samlsts "browser" key
+    // (set during first-run setup) until the user explicitly saves a choice here.
+    public String getBrowser() {
+        String value = getConfig("browser");
+        return value != null ? value : "chrome"; // Default Chrome
+    }
+
+    public void setBrowser(String browser) {
+        setConfig("browser", browser);
+    }
+
     // Token state methods
     public void updateExpiration(String profileName, Instant expiration) {
         if (profileName == null || expiration == null) {

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -542,7 +542,7 @@ public class SwingMain extends JFrame {
     }
 
     private void showConfigurationDialog() {
-        ConfigurationDialog dialog = new ConfigurationDialog(this, databaseManager, passwordManager);
+        ConfigurationDialog dialog = new ConfigurationDialog(this, configManager, databaseManager, passwordManager);
         dialog.setVisible(true);
     }
 


### PR DESCRIPTION
## Summary
- Adds a Browser (Chrome/Firefox) selector to the post-setup Configuration/Settings dialog, exposing the existing `ConfigManager.getBrowserType()` -> `SamlAuthenticator.createWebDriver()` mechanism for editing after first-run setup.
- `DatabaseManager` gains `getBrowser()`/`setBrowser()`, mirroring the existing `theme` setting pattern. The DB row is intentionally not seeded with a default, so `ConfigManager.getBrowserType()` prioritizes an explicit DB save, then falls back to the `samlsts` INI `browser` key (set during first-run setup), then `"chrome"`.
- `SwingMain` threads its existing `configManager` field into `ConfigurationDialog` so the dialog can show/save the effective browser choice.

Closes #51

## Test plan
- [x] Compiled via `mvn compile` inside the `festive_bardeen` Docker container
- [ ] User to verify locally: open Settings, change Browser to Firefox, save, and confirm SAML login launches Firefox instead of Chrome