### PR TITLE
Add progress bar during credential login, fix status-poll clobbering

### DIFF
--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -38,7 +38,9 @@ public class SwingMain extends JFrame {
     private JTable tokenStatusTable;
     private JLabel lastRefreshedLabel;
     private JLabel statusLabel;
+    private JProgressBar loginProgressBar;
     private Timer statusRefreshTimer;
+    private volatile boolean credentialRequestInProgress = false;
 
     private ConfigManager configManager;
     private CredentialManager credentialManager;
@@ -154,6 +156,11 @@ public class SwingMain extends JFrame {
         statusPanel.setBorder(BorderFactory.createLoweredBevelBorder());
         statusLabel = new JLabel("Ready");
         statusPanel.add(statusLabel);
+        loginProgressBar = new JProgressBar();
+        loginProgressBar.setPreferredSize(new Dimension(120, 16));
+        loginProgressBar.setIndeterminate(true);
+        loginProgressBar.setVisible(false);
+        statusPanel.add(loginProgressBar);
         add(statusPanel, BorderLayout.SOUTH);
 
         pack();
@@ -404,9 +411,13 @@ public class SwingMain extends JFrame {
             }
 
             lastRefreshedLabel.setText("Last refreshed: " + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
-            statusLabel.setText("Status refreshed.");
+            if (!credentialRequestInProgress) {
+                statusLabel.setText("Status refreshed.");
+            }
         } catch (Exception e) {
-            statusLabel.setText("Failed to update status table: " + e.getMessage());
+            if (!credentialRequestInProgress) {
+                statusLabel.setText("Failed to update status table: " + e.getMessage());
+            }
             System.err.println("Status table update failed: " + e.getMessage());
             e.printStackTrace();
         }
@@ -482,6 +493,8 @@ public class SwingMain extends JFrame {
             // Disable button during processing
             requestCredentialsButton.setEnabled(false);
             requestCredentialsButton.setText("Requesting...");
+            credentialRequestInProgress = true;
+            loginProgressBar.setVisible(true);
             statusLabel.setText("Starting credential request for profile: " + selectedProfile + "...");
 
             // Run credential request in background thread
@@ -502,16 +515,20 @@ public class SwingMain extends JFrame {
                 protected void done() {
                     requestCredentialsButton.setEnabled(true);
                     requestCredentialsButton.setText("Request Credentials");
+                    credentialRequestInProgress = false;
+                    loginProgressBar.setVisible(false);
 
                     try {
                         get(); // Check for exceptions
                         refreshStatusTable();
                         updateCredentialButtons();
+                        statusLabel.setText("Credentials successfully obtained for profile: " + selectedProfile);
                         JOptionPane.showMessageDialog(SwingMain.this,
                             "Credentials successfully obtained for profile: " + selectedProfile,
                             "Success",
                             JOptionPane.INFORMATION_MESSAGE);
                     } catch (Exception ex) {
+                        statusLabel.setText("Error obtaining credentials: " + ex.getMessage());
                         JOptionPane.showMessageDialog(SwingMain.this,
                             "Error obtaining credentials: " + ex.getMessage(),
                             "Authentication Error",


### PR DESCRIPTION
## Summary
- Adds a visible indeterminate progress bar while a Selenium-based credential login is in flight (previously only a button-text change, no indicator despite the flow taking 10-30+ seconds for MFA/browser load).
- Fixes a bug where the 30s background status-poll timer (`startStatusPolling`) unconditionally overwrote the status label with "Status refreshed.", clobbering useful in-flight messages like "Sending Okta MFA push..." if the timer fired mid-login. Guarded via a `credentialRequestInProgress` flag.
- Success/error outcomes now also update the status label (not just the popup dialog), so the last state remains visible after the dialog is dismissed.

Closes #53

## Test plan
- [x] Compiled via `mvn compile` inside the `festive_bardeen` Docker container
- [x] Verified locally