### PR TITLE
Add in-app profile management (add/edit/delete)

### DIFF
--- a/src/main/java/com/ourgiant/saml/ConfigManager.java
+++ b/src/main/java/com/ourgiant/saml/ConfigManager.java
@@ -278,6 +278,48 @@ public class ConfigManager {
     }
 
     /**
+     * Get list of configured identity provider section names (e.g. "Fed-Okta")
+     */
+    public List<String> getIdpProviders() {
+        List<String> idps = new ArrayList<>();
+        for (String section : config.keySet()) {
+            if (section.startsWith("Fed-")) {
+                idps.add(section);
+            }
+        }
+        idps.sort(String.CASE_INSENSITIVE_ORDER);
+        return idps;
+    }
+
+    /**
+     * Creates or updates a profile section with the given fields and persists to disk.
+     */
+    public void saveProfile(String profileName, Map<String, String> fields) throws Exception {
+        Profile.Section section = config.get(profileName);
+        if (section == null) {
+            section = config.add(profileName);
+        }
+        for (Map.Entry<String, String> entry : fields.entrySet()) {
+            section.put(entry.getKey(), entry.getValue());
+        }
+        persistConfig();
+    }
+
+    /**
+     * Removes a profile section and persists to disk.
+     */
+    public void deleteProfile(String profileName) throws Exception {
+        config.remove(profileName);
+        persistConfig();
+    }
+
+    private void persistConfig() throws Exception {
+        File configFile = new File(configFilePath);
+        config.store(configFile);
+        logger.info("Configuration file updated at: {}", configFilePath);
+    }
+
+    /**
      * Returns true if the config file exists on disk.
      */
     public static boolean configFileExists() {

--- a/src/main/java/com/ourgiant/saml/ProfileEditDialog.java
+++ b/src/main/java/com/ourgiant/saml/ProfileEditDialog.java
@@ -1,0 +1,147 @@
+package com.ourgiant.saml;
+
+import org.ini4j.Profile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Dialog for adding or editing a single AWS profile in ~/.aws/samlsts.
+ */
+public class ProfileEditDialog extends JDialog {
+    private static final Logger logger = LoggerFactory.getLogger(ProfileEditDialog.class);
+
+    private final ConfigManager configManager;
+    private final String originalProfileName; // null when adding a new profile
+
+    private JTextField profileNameField;
+    private JComboBox<String> samlProviderCombo;
+    private JTextField accountNumberField;
+    private JTextField iamRoleField;
+
+    private boolean saved = false;
+
+    public ProfileEditDialog(Frame parent, ConfigManager configManager, String profileName) {
+        super(parent, profileName == null ? "Add Profile" : "Edit Profile", true);
+        this.configManager = configManager;
+        this.originalProfileName = profileName;
+
+        initializeUI();
+        if (profileName != null) {
+            loadExistingProfile(profileName);
+        }
+        pack();
+        setMinimumSize(new Dimension(380, getHeight()));
+        setLocationRelativeTo(parent);
+    }
+
+    public boolean isSaved() {
+        return saved;
+    }
+
+    private void initializeUI() {
+        setLayout(new BorderLayout());
+
+        JPanel panel = new JPanel(new GridBagLayout());
+        panel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(4, 6, 4, 6);
+        gbc.anchor = GridBagConstraints.WEST;
+
+        gbc.gridx = 0; gbc.gridy = 0;
+        panel.add(new JLabel("Profile Name:"), gbc);
+        gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
+        profileNameField = new JTextField();
+        panel.add(profileNameField, gbc);
+
+        gbc.gridx = 0; gbc.gridy = 1; gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
+        panel.add(new JLabel("Identity Provider:"), gbc);
+        gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
+        samlProviderCombo = new JComboBox<>(configManager.getIdpProviders().toArray(new String[0]));
+        panel.add(samlProviderCombo, gbc);
+
+        gbc.gridx = 0; gbc.gridy = 2; gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
+        panel.add(new JLabel("Account Number:"), gbc);
+        gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
+        accountNumberField = new JTextField();
+        panel.add(accountNumberField, gbc);
+
+        gbc.gridx = 0; gbc.gridy = 3; gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
+        panel.add(new JLabel("IAM Role Name:"), gbc);
+        gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
+        iamRoleField = new JTextField();
+        panel.add(iamRoleField, gbc);
+
+        add(panel, BorderLayout.CENTER);
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton cancelButton = new JButton("Cancel");
+        JButton saveButton = new JButton("Save");
+        cancelButton.addActionListener(e -> setVisible(false));
+        saveButton.addActionListener(e -> onSave());
+        buttonPanel.add(cancelButton);
+        buttonPanel.add(saveButton);
+        add(buttonPanel, BorderLayout.SOUTH);
+    }
+
+    private void loadExistingProfile(String profileName) {
+        profileNameField.setText(profileName);
+
+        Profile.Section section = configManager.getProfile(profileName);
+        if (section == null) {
+            return;
+        }
+        accountNumberField.setText(section.get("accountnumber", ""));
+        iamRoleField.setText(section.get("iamrole", ""));
+        samlProviderCombo.setSelectedItem(section.get("samlprovider", ""));
+    }
+
+    private void onSave() {
+        String profileName = profileNameField.getText().trim();
+        String samlProvider = (String) samlProviderCombo.getSelectedItem();
+        String accountNumber = accountNumberField.getText().trim();
+        String iamRole = iamRoleField.getText().trim();
+
+        if (profileName.isEmpty() || samlProvider == null || accountNumber.isEmpty() || iamRole.isEmpty()) {
+            JOptionPane.showMessageDialog(this,
+                "All fields are required.",
+                "Missing Fields",
+                JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        boolean isRename = originalProfileName != null && !originalProfileName.equals(profileName);
+        boolean isNewName = originalProfileName == null || isRename;
+        if (isNewName && configManager.getAvailableProfiles().contains(profileName)) {
+            JOptionPane.showMessageDialog(this,
+                "A profile named \"" + profileName + "\" already exists.",
+                "Duplicate Profile Name",
+                JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("accountnumber", accountNumber);
+        fields.put("iamrole", iamRole);
+        fields.put("samlprovider", samlProvider);
+
+        try {
+            if (isRename) {
+                configManager.deleteProfile(originalProfileName);
+            }
+            configManager.saveProfile(profileName, fields);
+            saved = true;
+            setVisible(false);
+        } catch (Exception ex) {
+            logger.error("Failed to save profile: {}", profileName, ex);
+            JOptionPane.showMessageDialog(this,
+                "Failed to save profile: " + ex.getMessage(),
+                "Error",
+                JOptionPane.ERROR_MESSAGE);
+        }
+    }
+}

--- a/src/main/java/com/ourgiant/saml/ProfileManagerDialog.java
+++ b/src/main/java/com/ourgiant/saml/ProfileManagerDialog.java
@@ -1,0 +1,149 @@
+package com.ourgiant.saml;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Dialog for listing, adding, editing, and deleting AWS profiles in ~/.aws/samlsts.
+ */
+public class ProfileManagerDialog extends JDialog {
+    private static final Logger logger = LoggerFactory.getLogger(ProfileManagerDialog.class);
+
+    private final ConfigManager configManager;
+    private final DefaultListModel<String> profileListModel = new DefaultListModel<>();
+    private final JList<String> profileList = new JList<>(profileListModel);
+    private boolean profilesChanged = false;
+
+    public ProfileManagerDialog(Frame parent, ConfigManager configManager) {
+        super(parent, "Manage Profiles", true);
+        this.configManager = configManager;
+
+        initializeUI();
+        loadProfileList();
+        pack();
+        setMinimumSize(new Dimension(420, 320));
+        setLocationRelativeTo(parent);
+    }
+
+    /**
+     * True if any profile was added, edited, or deleted while this dialog was open.
+     */
+    public boolean isProfilesChanged() {
+        return profilesChanged;
+    }
+
+    private void initializeUI() {
+        setLayout(new BorderLayout(8, 8));
+        ((JComponent) getContentPane()).setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+
+        profileList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        add(new JScrollPane(profileList), BorderLayout.CENTER);
+
+        JPanel sideButtonPanel = new JPanel();
+        sideButtonPanel.setLayout(new BoxLayout(sideButtonPanel, BoxLayout.Y_AXIS));
+
+        JButton addButton = new JButton("Add...");
+        JButton editButton = new JButton("Edit...");
+        JButton deleteButton = new JButton("Delete");
+        addButton.addActionListener(e -> onAdd());
+        editButton.addActionListener(e -> onEdit());
+        deleteButton.addActionListener(e -> onDelete());
+
+        for (JButton button : new JButton[]{addButton, editButton, deleteButton}) {
+            button.setAlignmentX(Component.LEFT_ALIGNMENT);
+            button.setMaximumSize(new Dimension(Integer.MAX_VALUE, button.getPreferredSize().height));
+            sideButtonPanel.add(button);
+            sideButtonPanel.add(Box.createVerticalStrut(6));
+        }
+        sideButtonPanel.add(Box.createVerticalGlue());
+
+        add(sideButtonPanel, BorderLayout.EAST);
+
+        JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton closeButton = new JButton("Close");
+        closeButton.addActionListener(e -> setVisible(false));
+        bottomPanel.add(closeButton);
+        add(bottomPanel, BorderLayout.SOUTH);
+    }
+
+    private void loadProfileList() {
+        String previouslySelected = profileList.getSelectedValue();
+        profileListModel.clear();
+        for (String profile : configManager.getAvailableProfiles()) {
+            profileListModel.addElement(profile);
+        }
+        if (previouslySelected != null) {
+            profileList.setSelectedValue(previouslySelected, true);
+        }
+    }
+
+    private void onAdd() {
+        if (configManager.getIdpProviders().isEmpty()) {
+            JOptionPane.showMessageDialog(this,
+                "No identity providers are configured. Add one to ~/.aws/samlsts before creating a profile.",
+                "No Identity Providers",
+                JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        ProfileEditDialog dialog = new ProfileEditDialog((Frame) getParent(), configManager, null);
+        dialog.setVisible(true);
+        if (dialog.isSaved()) {
+            profilesChanged = true;
+            loadProfileList();
+        }
+    }
+
+    private void onEdit() {
+        String selected = profileList.getSelectedValue();
+        if (selected == null) {
+            JOptionPane.showMessageDialog(this,
+                "Select a profile to edit.",
+                "No Profile Selected",
+                JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        ProfileEditDialog dialog = new ProfileEditDialog((Frame) getParent(), configManager, selected);
+        dialog.setVisible(true);
+        if (dialog.isSaved()) {
+            profilesChanged = true;
+            loadProfileList();
+        }
+    }
+
+    private void onDelete() {
+        String selected = profileList.getSelectedValue();
+        if (selected == null) {
+            JOptionPane.showMessageDialog(this,
+                "Select a profile to delete.",
+                "No Profile Selected",
+                JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        int confirm = JOptionPane.showConfirmDialog(this,
+            "Delete profile \"" + selected + "\"? This cannot be undone.",
+            "Delete Profile",
+            JOptionPane.YES_NO_OPTION,
+            JOptionPane.WARNING_MESSAGE);
+        if (confirm != JOptionPane.YES_OPTION) {
+            return;
+        }
+
+        try {
+            configManager.deleteProfile(selected);
+            profilesChanged = true;
+            loadProfileList();
+        } catch (Exception ex) {
+            logger.error("Failed to delete profile: {}", selected, ex);
+            JOptionPane.showMessageDialog(this,
+                "Failed to delete profile: " + ex.getMessage(),
+                "Error",
+                JOptionPane.ERROR_MESSAGE);
+        }
+    }
+}

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -171,6 +171,10 @@ public class SwingMain extends JFrame {
         JMenuBar menuBar = new JMenuBar();
         JMenu fileMenu = new JMenu("File");
 
+        JMenuItem manageProfilesMenuItem = new JMenuItem("Manage Profiles...");
+        manageProfilesMenuItem.addActionListener(e -> showProfileManagerDialog());
+        fileMenu.add(manageProfilesMenuItem);
+
         JMenuItem configMenuItem = new JMenuItem("Configuration...");
         configMenuItem.addActionListener(e -> showConfigurationDialog());
         fileMenu.add(configMenuItem);
@@ -561,6 +565,15 @@ public class SwingMain extends JFrame {
     private void showConfigurationDialog() {
         ConfigurationDialog dialog = new ConfigurationDialog(this, configManager, databaseManager, passwordManager);
         dialog.setVisible(true);
+    }
+
+    private void showProfileManagerDialog() {
+        ProfileManagerDialog dialog = new ProfileManagerDialog(this, configManager);
+        dialog.setVisible(true);
+        if (dialog.isProfilesChanged()) {
+            loadProfiles();
+            refreshStatusTable();
+        }
     }
 
     private void showCredentialsDialog(boolean showEncrypted, boolean showPlaintext) {


### PR DESCRIPTION
## Summary
- Adds a "Manage Profiles..." dialog (File menu) for CRUD on AWS profiles in `~/.aws/samlsts`, previously only writable once via the first-run setup wizard.
- `ProfileManagerDialog` lists existing profiles with Add / Edit / Delete actions.
- `ProfileEditDialog` collects profile name, identity provider (from existing configured `Fed-*` sections), AWS account number, and IAM role name. Handles renames (delete-old + save-new) and duplicate-name checks.
- `ConfigManager` gains `getIdpProviders()`, `saveProfile()`, `deleteProfile()` to incrementally mutate and persist the already-loaded INI in place, rather than requiring a full-wizard rewrite.
- Main window refreshes the profile combo box and status table automatically after any change.

Closes #55

## Test plan
- [x] Compiled via `mvn compile` inside the `festive_bardeen` Docker container
- [x] `mvn test` passes
- [x] Verified the ini4j read/write round-trip directly (add → edit → rename → delete across multiple reload cycles): edits replace values cleanly with no duplicate accumulation, `global`/`Fed-*` sections stay intact
- [x] Verified locally