### PR TITLE
Add keyboard shortcuts and tooltips across the UI

### DIFF
--- a/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
+++ b/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
@@ -7,6 +7,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 
 /**
  * Configuration dialog for setting application options.
@@ -63,7 +64,9 @@ public class ConfigurationDialog extends JDialog {
 
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         saveButton = new JButton("Save");
+        saveButton.setMnemonic(KeyEvent.VK_S);
         cancelButton = new JButton("Cancel");
+        cancelButton.setMnemonic(KeyEvent.VK_C);
         saveButton.addActionListener(new SaveActionListener());
         cancelButton.addActionListener(e -> setVisible(false));
         buttonPanel.add(cancelButton);
@@ -85,6 +88,7 @@ public class ConfigurationDialog extends JDialog {
             databaseManager.getMaxDuration() / 60,
             15
         ));
+        durationSpinner.setToolTipText("How long requested AWS credentials remain valid before they expire");
         panel.add(durationSpinner, gbc);
 
         return panel;
@@ -96,7 +100,9 @@ public class ConfigurationDialog extends JDialog {
 
         gbc.gridx = 0; gbc.gridy = 0; gbc.gridwidth = 2;
         storePasswordCheckBox = new JCheckBox("Store and use Okta password");
+        storePasswordCheckBox.setMnemonic(KeyEvent.VK_T);
         storePasswordCheckBox.addActionListener(e -> updatePasswordExpirationEnabled());
+        storePasswordCheckBox.setToolTipText("Securely cache your Okta password locally so you're not prompted for it every login");
         panel.add(storePasswordCheckBox, gbc);
         gbc.gridwidth = 1;
 
@@ -108,13 +114,16 @@ public class ConfigurationDialog extends JDialog {
             databaseManager.getPasswordExpirationMinutes(), 15, 10080, 60
         ));
         passwordExpirationSpinner.setEnabled(false);
+        passwordExpirationSpinner.setToolTipText("How long the stored password stays cached before you must re-enter it");
         panel.add(passwordExpirationSpinner, gbc);
         gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
 
         gbc.gridx = 1; gbc.gridy = 2; gbc.anchor = GridBagConstraints.EAST;
         forgetPasswordButton = new JButton("Forget Password");
+        forgetPasswordButton.setMnemonic(KeyEvent.VK_G);
         forgetPasswordButton.setEnabled(false);
         forgetPasswordButton.addActionListener(e -> forgetStoredPassword());
+        forgetPasswordButton.setToolTipText("Clear the securely stored password immediately");
         panel.add(forgetPasswordButton, gbc);
 
         return panel;
@@ -132,6 +141,7 @@ public class ConfigurationDialog extends JDialog {
         for (String theme : ThemeManager.getAvailableThemeNames()) {
             themeComboBox.addItem(theme);
         }
+        themeComboBox.setToolTipText("Application color theme");
         panel.add(themeComboBox, gbc);
 
         return panel;
@@ -146,6 +156,7 @@ public class ConfigurationDialog extends JDialog {
 
         gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
         browserComboBox = new JComboBox<>(BROWSERS);
+        browserComboBox.setToolTipText("Browser used to drive the SAML login flow");
         panel.add(browserComboBox, gbc);
 
         return panel;
@@ -157,6 +168,8 @@ public class ConfigurationDialog extends JDialog {
 
         gbc.gridx = 0; gbc.gridy = 0; gbc.gridwidth = 2;
         useFastPassCheckBox = new JCheckBox("Use Okta FastPass");
+        useFastPassCheckBox.setMnemonic(KeyEvent.VK_U);
+        useFastPassCheckBox.setToolTipText("Attempt Okta FastPass (device-based) login before falling back to password entry");
         panel.add(useFastPassCheckBox, gbc);
 
         return panel;

--- a/src/main/java/com/ourgiant/saml/CredentialsDialog.java
+++ b/src/main/java/com/ourgiant/saml/CredentialsDialog.java
@@ -7,6 +7,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Clipboard;
+import java.awt.event.KeyEvent;
 
 /**
  * Dialog for displaying credentials in various formats.
@@ -54,6 +55,7 @@ public class CredentialsDialog extends JDialog {
         // Button panel
         JPanel buttonPanel = new JPanel(new FlowLayout());
         JButton closeButton = new JButton("Close");
+        closeButton.setMnemonic(KeyEvent.VK_L);
         closeButton.addActionListener(e -> setVisible(false));
         buttonPanel.add(closeButton);
         add(buttonPanel, BorderLayout.SOUTH);
@@ -77,6 +79,7 @@ public class CredentialsDialog extends JDialog {
         textArea.setText(sb.toString());
 
         JButton copyButton = new JButton("Copy to Clipboard");
+        copyButton.setMnemonic(KeyEvent.VK_C);
         copyButton.addActionListener(e -> copyToClipboard(textArea.getText()));
 
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
@@ -110,6 +113,7 @@ public class CredentialsDialog extends JDialog {
         }
 
         JButton copyButton = new JButton("Copy to Clipboard");
+        copyButton.setMnemonic(KeyEvent.VK_C);
         copyButton.addActionListener(e -> copyToClipboard(textArea.getText()));
 
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));

--- a/src/main/java/com/ourgiant/saml/FirstRunSetupDialog.java
+++ b/src/main/java/com/ourgiant/saml/FirstRunSetupDialog.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.KeyEvent;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -91,7 +92,9 @@ public class FirstRunSetupDialog extends JDialog {
 
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         JButton cancelButton = new JButton("Cancel");
+        cancelButton.setMnemonic(KeyEvent.VK_C);
         JButton saveButton = new JButton("Save & Launch");
+        saveButton.setMnemonic(KeyEvent.VK_S);
         cancelButton.addActionListener(e -> confirmCancel());
         saveButton.addActionListener(e -> save());
         buttonPanel.add(cancelButton);
@@ -125,6 +128,7 @@ public class FirstRunSetupDialog extends JDialog {
         panel.add(new JLabel("Session Duration (minutes):"), gbc);
         gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
         sessionDurationSpinner = new JSpinner(new SpinnerNumberModel(240, 15, 720, 15));
+        sessionDurationSpinner.setToolTipText("How long requested AWS credentials remain valid before they expire");
         panel.add(sessionDurationSpinner, gbc);
 
         return panel;
@@ -139,6 +143,7 @@ public class FirstRunSetupDialog extends JDialog {
         gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
         idpTypeCombo = new JComboBox<>(IDP_PRESETS.keySet().toArray(new String[0]));
         idpTypeCombo.addActionListener(e -> applyIdpPreset());
+        idpTypeCombo.setToolTipText("Prefills the fields below with a starting point for this identity provider");
         panel.add(idpTypeCombo, gbc);
 
         gbc.gridx = 0; gbc.gridy = 1; gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
@@ -151,12 +156,14 @@ public class FirstRunSetupDialog extends JDialog {
         panel.add(new JLabel("Login Page URL:"), gbc);
         gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
         loginPageField = new JTextField();
+        loginPageField.setToolTipText("The SAML-initiated login URL your browser is sent to first");
         panel.add(loginPageField, gbc);
 
         gbc.gridx = 0; gbc.gridy = 3; gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
         panel.add(new JLabel("Login Page Title:"), gbc);
         gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
         loginTitleField = new JTextField();
+        loginTitleField.setToolTipText("The browser page title used to detect that the login page has loaded");
         panel.add(loginTitleField, gbc);
 
         applyIdpPreset();

--- a/src/main/java/com/ourgiant/saml/ProfileEditDialog.java
+++ b/src/main/java/com/ourgiant/saml/ProfileEditDialog.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.KeyEvent;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -53,34 +54,42 @@ public class ProfileEditDialog extends JDialog {
         gbc.anchor = GridBagConstraints.WEST;
 
         gbc.gridx = 0; gbc.gridy = 0;
-        panel.add(new JLabel("Profile Name:"), gbc);
+        JLabel profileNameLabel = new JLabel("Profile Name:");
+        panel.add(profileNameLabel, gbc);
         gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
         profileNameField = new JTextField();
+        profileNameField.setToolTipText("The name AWS CLI/SDK tools will reference via --profile or AWS_PROFILE");
+        profileNameLabel.setLabelFor(profileNameField);
         panel.add(profileNameField, gbc);
 
         gbc.gridx = 0; gbc.gridy = 1; gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
         panel.add(new JLabel("Identity Provider:"), gbc);
         gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
         samlProviderCombo = new JComboBox<>(configManager.getIdpProviders().toArray(new String[0]));
+        samlProviderCombo.setToolTipText("Which configured identity provider handles login for this profile");
         panel.add(samlProviderCombo, gbc);
 
         gbc.gridx = 0; gbc.gridy = 2; gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
         panel.add(new JLabel("Account Number:"), gbc);
         gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
         accountNumberField = new JTextField();
+        accountNumberField.setToolTipText("The 12-digit AWS account number to assume a role in");
         panel.add(accountNumberField, gbc);
 
         gbc.gridx = 0; gbc.gridy = 3; gbc.fill = GridBagConstraints.NONE; gbc.weightx = 0;
         panel.add(new JLabel("IAM Role Name:"), gbc);
         gbc.gridx = 1; gbc.fill = GridBagConstraints.HORIZONTAL; gbc.weightx = 1.0;
         iamRoleField = new JTextField();
+        iamRoleField.setToolTipText("The IAM role name (not the full ARN) to assume via the SAML response");
         panel.add(iamRoleField, gbc);
 
         add(panel, BorderLayout.CENTER);
 
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         JButton cancelButton = new JButton("Cancel");
+        cancelButton.setMnemonic(KeyEvent.VK_C);
         JButton saveButton = new JButton("Save");
+        saveButton.setMnemonic(KeyEvent.VK_S);
         cancelButton.addActionListener(e -> setVisible(false));
         saveButton.addActionListener(e -> onSave());
         buttonPanel.add(cancelButton);

--- a/src/main/java/com/ourgiant/saml/ProfileManagerDialog.java
+++ b/src/main/java/com/ourgiant/saml/ProfileManagerDialog.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.KeyEvent;
 
 /**
  * Dialog for listing, adding, editing, and deleting AWS profiles in ~/.aws/samlsts.
@@ -40,14 +41,21 @@ public class ProfileManagerDialog extends JDialog {
         ((JComponent) getContentPane()).setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
 
         profileList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        profileList.setToolTipText("Configured AWS profiles");
         add(new JScrollPane(profileList), BorderLayout.CENTER);
 
         JPanel sideButtonPanel = new JPanel();
         sideButtonPanel.setLayout(new BoxLayout(sideButtonPanel, BoxLayout.Y_AXIS));
 
         JButton addButton = new JButton("Add...");
+        addButton.setMnemonic(KeyEvent.VK_A);
+        addButton.setToolTipText("Add a new AWS profile");
         JButton editButton = new JButton("Edit...");
+        editButton.setMnemonic(KeyEvent.VK_E);
+        editButton.setToolTipText("Edit the selected profile");
         JButton deleteButton = new JButton("Delete");
+        deleteButton.setMnemonic(KeyEvent.VK_D);
+        deleteButton.setToolTipText("Delete the selected profile");
         addButton.addActionListener(e -> onAdd());
         editButton.addActionListener(e -> onEdit());
         deleteButton.addActionListener(e -> onDelete());
@@ -64,6 +72,7 @@ public class ProfileManagerDialog extends JDialog {
 
         JPanel bottomPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         JButton closeButton = new JButton("Close");
+        closeButton.setMnemonic(KeyEvent.VK_L);
         closeButton.addActionListener(e -> setVisible(false));
         bottomPanel.add(closeButton);
         add(bottomPanel, BorderLayout.SOUTH);

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -9,6 +9,8 @@ import javax.swing.table.DefaultTableModel;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -84,28 +86,39 @@ public class SwingMain extends JFrame {
 
         // Profile selection panel
         JPanel profilePanel = new JPanel(new FlowLayout());
-        profilePanel.add(new JLabel("Select Profile:"));
+        JLabel selectProfileLabel = new JLabel("Select Profile:");
+        profilePanel.add(selectProfileLabel);
         profileComboBox = new JComboBox<>();
         profileComboBox.setPreferredSize(new Dimension(220, 25));
         profileComboBox.addActionListener(e -> updateCredentialButtons());
+        profileComboBox.setToolTipText("The AWS profile to authenticate and fetch credentials for");
+        selectProfileLabel.setLabelFor(profileComboBox);
         profilePanel.add(profileComboBox);
 
         requestCredentialsButton = new JButton("Request Credentials");
+        requestCredentialsButton.setMnemonic(KeyEvent.VK_R);
         requestCredentialsButton.addActionListener(new RequestCredentialsListener());
+        requestCredentialsButton.setToolTipText("Launch browser login and fetch AWS credentials for the selected profile");
         profilePanel.add(requestCredentialsButton);
 
         showBrowserCheckBox = new JCheckBox("Show browser");
+        showBrowserCheckBox.setMnemonic(KeyEvent.VK_B);
         showBrowserCheckBox.setSelected(false);
+        showBrowserCheckBox.setToolTipText("Show the browser window during login instead of running it headless");
         profilePanel.add(showBrowserCheckBox);
 
         showEncryptedButton = new JButton("Encrypted");
+        showEncryptedButton.setMnemonic(KeyEvent.VK_N);
         showEncryptedButton.addActionListener(e -> showCredentialsDialog(true, false));
         showEncryptedButton.setEnabled(false); // Initially disabled until credentials are available
+        showEncryptedButton.setToolTipText("View encrypted credentials for use with deployment tools");
         profilePanel.add(showEncryptedButton);
 
         showCredentialsButton = new JButton("Show Credentials");
+        showCredentialsButton.setMnemonic(KeyEvent.VK_C);
         showCredentialsButton.addActionListener(e -> showCredentialsDialog(false, true));
         showCredentialsButton.setEnabled(false); // Initially disabled until credentials are available
+        showCredentialsButton.setToolTipText("View plaintext AWS credentials for the selected profile");
         profilePanel.add(showCredentialsButton);
 
         add(profilePanel, BorderLayout.NORTH);
@@ -124,6 +137,7 @@ public class SwingMain extends JFrame {
         tokenStatusTable = new JTable(tokenStatusTableModel);
         tokenStatusTable.setFillsViewportHeight(true);
         tokenStatusTable.setRowHeight(26);
+        tokenStatusTable.setToolTipText("Click a row to select that profile above");
         tokenStatusTable.getColumnModel().getColumn(1).setCellRenderer(new StatusTableCellRenderer());
         tokenStatusTable.addMouseListener(new java.awt.event.MouseAdapter() {
             @Override
@@ -141,7 +155,9 @@ public class SwingMain extends JFrame {
 
         JPanel statusControls = new JPanel(new FlowLayout(FlowLayout.RIGHT));
         JButton refreshStatusButton = new JButton("Refresh Status");
+        refreshStatusButton.setMnemonic(KeyEvent.VK_U);
         refreshStatusButton.addActionListener(e -> refreshStatusTable());
+        refreshStatusButton.setToolTipText("Recheck credential expiration status for all profiles");
         statusControls.add(refreshStatusButton);
         lastRefreshedLabel = new JLabel();
         statusControls.add(lastRefreshedLabel);
@@ -170,24 +186,32 @@ public class SwingMain extends JFrame {
     private JMenuBar createMenuBar() {
         JMenuBar menuBar = new JMenuBar();
         JMenu fileMenu = new JMenu("File");
+        fileMenu.setMnemonic(KeyEvent.VK_F);
 
         JMenuItem manageProfilesMenuItem = new JMenuItem("Manage Profiles...");
+        manageProfilesMenuItem.setMnemonic(KeyEvent.VK_M);
+        manageProfilesMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.CTRL_DOWN_MASK));
         manageProfilesMenuItem.addActionListener(e -> showProfileManagerDialog());
         fileMenu.add(manageProfilesMenuItem);
 
         JMenuItem configMenuItem = new JMenuItem("Configuration...");
+        configMenuItem.setMnemonic(KeyEvent.VK_C);
+        configMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_COMMA, InputEvent.CTRL_DOWN_MASK));
         configMenuItem.addActionListener(e -> showConfigurationDialog());
         fileMenu.add(configMenuItem);
 
         fileMenu.addSeparator();
 
         JMenuItem aboutMenuItem = new JMenuItem("About...");
+        aboutMenuItem.setMnemonic(KeyEvent.VK_A);
         aboutMenuItem.addActionListener(e -> showAboutDialog());
         fileMenu.add(aboutMenuItem);
 
         fileMenu.addSeparator();
 
         JMenuItem exitMenuItem = new JMenuItem("Exit");
+        exitMenuItem.setMnemonic(KeyEvent.VK_X);
+        exitMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, InputEvent.CTRL_DOWN_MASK));
         exitMenuItem.addActionListener(e -> System.exit(0));
         fileMenu.add(exitMenuItem);
 


### PR DESCRIPTION
## Summary
- No component had mnemonics, accelerators, or tooltips before this — every action required the mouse, and non-obvious controls had no in-context explanation.
- Adds Alt+letter mnemonics to menu items, dialog buttons, and checkboxes across `SwingMain`, `ConfigurationDialog`, `ProfileManagerDialog`, `ProfileEditDialog`, `FirstRunSetupDialog`, and `CredentialsDialog`.
- Adds Ctrl+ accelerators for the most-used File menu actions: Manage Profiles (Ctrl+P), Configuration (Ctrl+,), Exit (Ctrl+Q).
- Adds tooltips on controls whose purpose isn't self-evident from the label alone (session duration, FastPass, browser/theme choice, IDP login page/title, encrypted vs. plaintext credentials, click-to-select status table row).
- `CredentialsDialog`'s encryption logic is untouched — only the Close/Copy buttons got mnemonics.

Closes #57

## Test plan
- [x] Compiled via `mvn compile` inside the `festive_bardeen` Docker container
- [x] `mvn test` passes
- [x] Verified locally