### PR TITLE
Add system tray icon with credential expiry notification

### DIFF
--- a/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
+++ b/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
@@ -27,6 +27,7 @@ public class ConfigurationDialog extends JDialog {
     private JComboBox<String> themeComboBox;
     private JComboBox<String> browserComboBox;
     private JCheckBox useFastPassCheckBox;
+    private JCheckBox trayNotificationsCheckBox;
     private JButton saveButton;
     private JButton cancelButton;
 
@@ -59,6 +60,7 @@ public class ConfigurationDialog extends JDialog {
         outerGbc.gridy = 2; outerPanel.add(buildAppearanceSection(), outerGbc);
         outerGbc.gridy = 3; outerPanel.add(buildBrowserSection(), outerGbc);
         outerGbc.gridy = 4; outerPanel.add(buildAuthSection(), outerGbc);
+        outerGbc.gridy = 5; outerPanel.add(buildNotificationsSection(), outerGbc);
 
         add(outerPanel, BorderLayout.CENTER);
 
@@ -175,6 +177,23 @@ public class ConfigurationDialog extends JDialog {
         return panel;
     }
 
+    private JPanel buildNotificationsSection() {
+        JPanel panel = titledPanel("Notifications");
+        GridBagConstraints gbc = sectionGbc();
+
+        gbc.gridx = 0; gbc.gridy = 0; gbc.gridwidth = 2;
+        trayNotificationsCheckBox = new JCheckBox("Show tray notification before credentials expire");
+        trayNotificationsCheckBox.setMnemonic(KeyEvent.VK_Y);
+        boolean traySupported = SystemTray.isSupported();
+        trayNotificationsCheckBox.setEnabled(traySupported);
+        trayNotificationsCheckBox.setToolTipText(traySupported
+            ? "Show a system tray notification a few minutes before a profile's AWS credentials expire"
+            : "System tray is not available on this platform/environment");
+        panel.add(trayNotificationsCheckBox, gbc);
+
+        return panel;
+    }
+
     private static JPanel titledPanel(String title) {
         JPanel panel = new JPanel(new GridBagLayout());
         panel.setBorder(BorderFactory.createTitledBorder(title));
@@ -228,6 +247,8 @@ public class ConfigurationDialog extends JDialog {
 
         useFastPassCheckBox.setSelected(databaseManager.getFastPassEnabled());
 
+        trayNotificationsCheckBox.setSelected(databaseManager.getTrayNotificationsEnabled());
+
         updatePasswordExpirationEnabled();
     }
 
@@ -254,8 +275,11 @@ public class ConfigurationDialog extends JDialog {
                 boolean useFastPass = useFastPassCheckBox.isSelected();
                 databaseManager.setFastPassEnabled(useFastPass);
 
-                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, browser = {}, use_fastpass = {}",
-                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, selectedBrowser, useFastPass);
+                boolean trayNotificationsEnabled = trayNotificationsCheckBox.isSelected();
+                databaseManager.setTrayNotificationsEnabled(trayNotificationsEnabled);
+
+                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, browser = {}, use_fastpass = {}, tray_notifications = {}",
+                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, selectedBrowser, useFastPass, trayNotificationsEnabled);
 
                 // Apply theme immediately
                 if (ThemeManager.applyTheme(selectedTheme)) {

--- a/src/main/java/com/ourgiant/saml/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/DatabaseManager.java
@@ -163,6 +163,15 @@ public class DatabaseManager {
         setConfig("use_fastpass", String.valueOf(enabled));
     }
 
+    public boolean getTrayNotificationsEnabled() {
+        String value = getConfig("tray_notifications_enabled");
+        return value == null || "true".equalsIgnoreCase(value); // Enabled by default
+    }
+
+    public void setTrayNotificationsEnabled(boolean enabled) {
+        setConfig("tray_notifications_enabled", String.valueOf(enabled));
+    }
+
     // Intentionally not seeded in insertDefaultConfig(): an absent value lets
     // ConfigManager.getBrowserType() fall back to the samlsts "browser" key
     // (set during first-run setup) until the user explicitly saves a choice here.

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -11,6 +11,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -19,7 +21,9 @@ import java.time.format.DateTimeFormatter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -29,6 +33,7 @@ import java.util.TreeSet;
  */
 public class SwingMain extends JFrame {
     private static final Logger logger = LoggerFactory.getLogger(SwingMain.class);
+    private static final Duration EXPIRY_WARNING_THRESHOLD = Duration.ofMinutes(5);
 
     private JComboBox<String> profileComboBox;
     private JCheckBox showBrowserCheckBox;
@@ -43,6 +48,9 @@ public class SwingMain extends JFrame {
     private JProgressBar loginProgressBar;
     private Timer statusRefreshTimer;
     private volatile boolean credentialRequestInProgress = false;
+
+    private TrayIcon trayIcon;
+    private final Map<String, Instant> lastNotifiedExpiration = new HashMap<>();
 
     private ConfigManager configManager;
     private CredentialManager credentialManager;
@@ -83,6 +91,7 @@ public class SwingMain extends JFrame {
 
         setWindowIcon();
         setJMenuBar(createMenuBar());
+        initializeSystemTray();
 
         // Profile selection panel
         JPanel profilePanel = new JPanel(new FlowLayout());
@@ -212,7 +221,7 @@ public class SwingMain extends JFrame {
         JMenuItem exitMenuItem = new JMenuItem("Exit");
         exitMenuItem.setMnemonic(KeyEvent.VK_X);
         exitMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, InputEvent.CTRL_DOWN_MASK));
-        exitMenuItem.addActionListener(e -> System.exit(0));
+        exitMenuItem.addActionListener(e -> exitApplication());
         fileMenu.add(exitMenuItem);
 
         menuBar.add(fileMenu);
@@ -387,10 +396,91 @@ public class SwingMain extends JFrame {
         }
     }
 
+    /**
+     * Sets up a system tray icon (supported on Windows, macOS, and most Linux desktop
+     * environments) so the app can keep monitoring credential expiration in the background
+     * after the window is closed. Falls back to normal exit-on-close if the tray, or icon
+     * loading, isn't available on this platform/environment.
+     */
+    private void initializeSystemTray() {
+        if (!SystemTray.isSupported()) {
+            logger.info("System tray is not supported on this platform; window close will exit the app.");
+            return;
+        }
+
+        try {
+            Image trayImage = Toolkit.getDefaultToolkit().getImage(getClass().getResource("/saml_swing_icon_small.png"));
+
+            PopupMenu trayMenu = new PopupMenu();
+            MenuItem showItem = new MenuItem("Show");
+            showItem.addActionListener(e -> restoreFromTray());
+            MenuItem exitItem = new MenuItem("Exit");
+            exitItem.addActionListener(e -> exitApplication());
+            trayMenu.add(showItem);
+            trayMenu.addSeparator();
+            trayMenu.add(exitItem);
+
+            trayIcon = new TrayIcon(trayImage, "AWS IDP SAML Client", trayMenu);
+            trayIcon.setImageAutoSize(true);
+            trayIcon.addActionListener(e -> restoreFromTray());
+            SystemTray.getSystemTray().add(trayIcon);
+
+            setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+            addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    setVisible(false);
+                }
+            });
+        } catch (Exception e) {
+            logger.warn("Failed to initialize system tray icon; window close will exit the app.", e);
+            trayIcon = null;
+        }
+    }
+
+    private void restoreFromTray() {
+        setVisible(true);
+        setExtendedState(JFrame.NORMAL);
+        toFront();
+        requestFocus();
+    }
+
+    private void exitApplication() {
+        if (trayIcon != null) {
+            SystemTray.getSystemTray().remove(trayIcon);
+        }
+        System.exit(0);
+    }
+
     private void startStatusPolling() {
         statusRefreshTimer = new Timer(30000, e -> refreshStatusTable());
         statusRefreshTimer.setRepeats(true);
         statusRefreshTimer.start();
+    }
+
+    /**
+     * Fires a tray notification the first time a profile's credentials cross into the
+     * expiry warning window, so the user doesn't have to keep the window open and watch
+     * the status table. Keyed by the exact expiration instant so a renewed credential
+     * (new expiration) can trigger a fresh notification later.
+     */
+    private void maybeNotifyExpiringSoon(String profile, Instant expiration, Duration remaining) {
+        if (trayIcon == null || !databaseManager.getTrayNotificationsEnabled()) {
+            return;
+        }
+        if (remaining.compareTo(EXPIRY_WARNING_THRESHOLD) > 0) {
+            return;
+        }
+        if (expiration.equals(lastNotifiedExpiration.get(profile))) {
+            return;
+        }
+
+        lastNotifiedExpiration.put(profile, expiration);
+        trayIcon.displayMessage(
+            "AWS credentials expiring soon",
+            "Profile \"" + profile + "\" expires in " + formatDuration(remaining) + ".",
+            TrayIcon.MessageType.WARNING
+        );
     }
 
     private void refreshStatusTable() {
@@ -417,7 +507,9 @@ public class SwingMain extends JFrame {
                 } else if (expiration.isAfter(now)) {
                     status = "VALID";
                     expiresAtText = formatInstant(expiration);
-                    timeRemaining = formatDuration(Duration.between(now, expiration));
+                    Duration remaining = Duration.between(now, expiration);
+                    timeRemaining = formatDuration(remaining);
+                    maybeNotifyExpiringSoon(profile, expiration, remaining);
                 } else {
                     status = "EXPIRED";
                     expiresAtText = formatInstant(expiration);


### PR DESCRIPTION
## Summary
- Adds a system tray icon via `java.awt.SystemTray` (supported on Windows, macOS, and most Linux desktop environments), with a Show/Exit popup menu and double-click-to-restore.
- When the tray is available, closing the main window hides it instead of exiting, so the existing 30s background status poll keeps running and can keep monitoring credential expiration without the window staying open.
- Fires a one-time tray notification when a profile's credentials cross into a 5-minute expiry warning window, keyed by the exact expiration instant so a renewed credential can trigger a fresh notification later.
- Gracefully falls back to normal exit-on-close when `SystemTray.isSupported()` is false (e.g. some headless/Linux environments) — verified this returns `false`, not an exception, in a headless container.
- Adds a "Notifications" section to Settings with a toggle, auto-disabled with an explanatory tooltip when the tray isn't available on the current platform.

Closes #59

## Test plan
- [x] Compiled via `mvn compile` inside the `festive_bardeen` Docker container
- [x] `mvn test` passes
- [x] Verified `SystemTray.isSupported()` degrades safely (returns `false`, no exception) in a headless environment
- [x] Verified locally