### PR TITLE
Add "Open Console" button to launch the AWS Console

### DIFF
--- a/src/main/java/com/ourgiant/saml/AwsConsoleLauncher.java
+++ b/src/main/java/com/ourgiant/saml/AwsConsoleLauncher.java
@@ -1,0 +1,62 @@
+package com.ourgiant.saml;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * Builds a one-time AWS Management Console sign-in URL from temporary STS credentials
+ * via the AWS federation endpoint, so a profile's console can be opened without manually
+ * pasting keys into the console login form.
+ *
+ * See: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
+ */
+public class AwsConsoleLauncher {
+    private static final String FEDERATION_ENDPOINT = "https://signin.aws.amazon.com/federation";
+    private static final String DEFAULT_DESTINATION = "https://console.aws.amazon.com/";
+
+    /**
+     * Calls the AWS federation endpoint and returns a one-time console sign-in URL.
+     * Note: SessionDuration must NOT be passed here — the federation endpoint rejects it
+     * for credentials obtained via AssumeRole* (which is how this app gets its credentials).
+     */
+    public static String buildLoginUrl(CredentialManager.AwsCredentials credentials) throws Exception {
+        String sessionJson = "{\"sessionId\":\"" + jsonEscape(credentials.getAccessKeyId())
+            + "\",\"sessionKey\":\"" + jsonEscape(credentials.getSecretAccessKey())
+            + "\",\"sessionToken\":\"" + jsonEscape(credentials.getSessionToken()) + "\"}";
+
+        String signinTokenUrl = FEDERATION_ENDPOINT + "?Action=getSigninToken&Session="
+            + URLEncoder.encode(sessionJson, StandardCharsets.UTF_8);
+
+        HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(signinTokenUrl))
+            .timeout(Duration.ofSeconds(15))
+            .GET()
+            .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("AWS federation endpoint returned HTTP " + response.statusCode());
+        }
+
+        String signinToken = SwingMain.extractJsonString(response.body(), "SigninToken");
+        if (signinToken == null) {
+            throw new IllegalStateException("AWS federation endpoint did not return a sign-in token");
+        }
+
+        return FEDERATION_ENDPOINT + "?Action=login"
+            + "&Destination=" + URLEncoder.encode(DEFAULT_DESTINATION, StandardCharsets.UTF_8)
+            + "&SigninToken=" + URLEncoder.encode(signinToken, StandardCharsets.UTF_8);
+    }
+
+    private static String jsonEscape(String value) {
+        return value == null ? "" : value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -40,6 +40,7 @@ public class SwingMain extends JFrame {
     private JButton requestCredentialsButton;
     private JButton showEncryptedButton;
     private JButton showCredentialsButton;
+    private JButton openConsoleButton;
 
     private DefaultTableModel tokenStatusTableModel;
     private JTable tokenStatusTable;
@@ -129,6 +130,13 @@ public class SwingMain extends JFrame {
         showCredentialsButton.setEnabled(false); // Initially disabled until credentials are available
         showCredentialsButton.setToolTipText("View plaintext AWS credentials for the selected profile");
         profilePanel.add(showCredentialsButton);
+
+        openConsoleButton = new JButton("Open Console");
+        openConsoleButton.setMnemonic(KeyEvent.VK_O);
+        openConsoleButton.addActionListener(e -> openAwsConsole());
+        openConsoleButton.setEnabled(false); // Initially disabled until credentials are available
+        openConsoleButton.setToolTipText("Open the AWS Management Console in your browser using the selected profile's credentials");
+        profilePanel.add(openConsoleButton);
 
         add(profilePanel, BorderLayout.NORTH);
 
@@ -726,6 +734,58 @@ public class SwingMain extends JFrame {
 
         showEncryptedButton.setEnabled(hasCredentials && hasPublicKey);
         showCredentialsButton.setEnabled(hasCredentials);
+        openConsoleButton.setEnabled(hasCredentials);
+    }
+
+    private void openAwsConsole() {
+        String selectedProfile = (String) profileComboBox.getSelectedItem();
+        if (selectedProfile == null) {
+            JOptionPane.showMessageDialog(this,
+                "Please select a profile first.",
+                "No Profile Selected",
+                JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        CredentialManager.AwsCredentials credentials = credentialManager.getCredentials(selectedProfile);
+        if (credentials == null) {
+            JOptionPane.showMessageDialog(this,
+                "No credentials found for profile: " + selectedProfile,
+                "No Credentials",
+                JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        openConsoleButton.setEnabled(false);
+        openConsoleButton.setText("Opening...");
+        statusLabel.setText("Opening AWS Console for profile: " + selectedProfile + "...");
+
+        SwingWorker<String, Void> worker = new SwingWorker<>() {
+            @Override
+            protected String doInBackground() throws Exception {
+                return AwsConsoleLauncher.buildLoginUrl(credentials);
+            }
+
+            @Override
+            protected void done() {
+                openConsoleButton.setEnabled(true);
+                openConsoleButton.setText("Open Console");
+
+                try {
+                    String loginUrl = get();
+                    Desktop.getDesktop().browse(new java.net.URI(loginUrl));
+                    statusLabel.setText("Opened AWS Console for profile: " + selectedProfile);
+                } catch (Exception ex) {
+                    statusLabel.setText("Failed to open AWS Console: " + ex.getMessage());
+                    logger.error("Failed to open AWS Console for profile: {}", selectedProfile, ex);
+                    JOptionPane.showMessageDialog(SwingMain.this,
+                        "Failed to open AWS Console: " + ex.getMessage(),
+                        "Error",
+                        JOptionPane.ERROR_MESSAGE);
+                }
+            }
+        };
+        worker.execute();
     }
 
     private static class TokenStatusRow {


### PR DESCRIPTION
## Summary
- Adds an "Open Console" button next to Show Credentials/Encrypted, enabled whenever the selected profile has credentials.
- `AwsConsoleLauncher` exchanges the profile's temporary STS credentials for a one-time AWS Console sign-in URL via the federation endpoint (`signin.aws.amazon.com/federation`), then opens it in the default browser.
- Deliberately omits `SessionDuration` in the federation request — AWS rejects that parameter for `AssumeRole*`-derived credentials, which is what this app always produces.
- Network call runs off the EDT via `SwingWorker`; button shows "Opening..." while in flight.

Previously the only way to use the console was to manually copy keys out of the Credentials dialog, which doesn't even work since the standard console login form doesn't accept temporary/session credentials.

Closes #61

## Test plan
- [x] Compiled via `mvn compile` inside the `festive_bardeen` Docker container
- [x] `mvn test` passes
- [x] Verified the real HTTP round-trip against AWS's live federation endpoint with intentionally bogus credentials (including special chars `"`, `\`, `+`, `/`) — got a clean HTTP 400 surfaced as a readable error, confirming JSON encoding and error handling both work
- [x] Verified locally