### PR TITLE
Add high-contrast dark theme candidates and fix theme live-refresh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,12 @@
             <artifactId>flatlaf-intellij-themes</artifactId>
             <version>3.4.1</version>
         </dependency>
+        <!-- FlatLaf Extras (FlatAnimatedLafChange for smooth theme-switch transitions) -->
+        <dependency>
+            <groupId>com.formdev</groupId>
+            <artifactId>flatlaf-extras</artifactId>
+            <version>3.4.1</version>
+        </dependency>
 
         <!-- Testing -->
         <dependency>

--- a/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
+++ b/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
@@ -281,10 +281,9 @@ public class ConfigurationDialog extends JDialog {
                 logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, browser = {}, use_fastpass = {}, tray_notifications = {}",
                     durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, selectedBrowser, useFastPass, trayNotificationsEnabled);
 
-                // Apply theme immediately
-                if (ThemeManager.applyTheme(selectedTheme)) {
-                    SwingUtilities.updateComponentTreeUI(getParent());
-                } else {
+                // Apply theme immediately — ThemeManager refreshes all open windows,
+                // including this dialog, so it re-themes live.
+                if (!ThemeManager.applyTheme(selectedTheme)) {
                     logger.warn("Failed to apply theme immediately: {}", selectedTheme);
                 }
 

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -1,5 +1,6 @@
 package com.ourgiant.saml;
 
+import com.formdev.flatlaf.FlatLaf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -704,13 +705,25 @@ public class SwingMain extends JFrame {
             if (column == 1 && value instanceof String status) {
                 switch (status) {
                     case "VALID" -> component.setForeground(new Color(0, 128, 0));
-                    case "EXPIRED" -> component.setForeground(Color.RED);
-                    default -> component.setForeground(Color.GRAY);
+                    case "EXPIRED" -> component.setForeground(expiredForeground());
+                    default -> component.setForeground(unknownForeground());
                 }
             } else {
                 component.setForeground(isSelected ? table.getSelectionForeground() : table.getForeground());
             }
             return component;
+        }
+
+        // Re-read per paint rather than caching statically so a theme switch takes effect immediately.
+        private static Color unknownForeground() {
+            Color disabled = UIManager.getColor("Label.disabledForeground");
+            return disabled != null ? disabled : Color.GRAY;
+        }
+
+        // FlatLaf.isLafDark() returns false for non-FlatLaf LaFs (Nimbus/Metal), which falls
+        // through to the light-background red — a sensible default there too.
+        private static Color expiredForeground() {
+            return FlatLaf.isLafDark() ? new Color(255, 110, 110) : Color.RED;
         }
     }
 
@@ -941,7 +954,24 @@ public class SwingMain extends JFrame {
                 }
             }
 
-            new SwingMain().setVisible(true);
+            SwingMain mainWindow = new SwingMain();
+            mainWindow.setVisible(true);
+            syncWindowPositionWithWindowManager(mainWindow);
         });
+    }
+
+    /**
+     * On Linux/X11 the window manager confirms a window's real on-screen position
+     * asynchronously after setVisible(true); FlatLaf's heavyweight popups (e.g. the
+     * File menu) compute their screen position from that value, so clicking a menu
+     * before the confirmation lands can render the popup at (0,0). Manually moving
+     * the window fixes it by forcing a fresh position round-trip — nudge it
+     * programmatically right after showing it so the fix applies before the user
+     * can click anything.
+     */
+    private static void syncWindowPositionWithWindowManager(Window window) {
+        Point location = window.getLocation();
+        window.setLocation(location.x + 1, location.y);
+        window.setLocation(location.x, location.y);
     }
 }

--- a/src/main/java/com/ourgiant/saml/ThemeManager.java
+++ b/src/main/java/com/ourgiant/saml/ThemeManager.java
@@ -1,12 +1,19 @@
 package com.ourgiant.saml;
 
+import com.formdev.flatlaf.FlatDarculaLaf;
+import com.formdev.flatlaf.FlatDarkLaf;
 import com.formdev.flatlaf.FlatLightLaf;
+import com.formdev.flatlaf.extras.FlatAnimatedLafChange;
+import com.formdev.flatlaf.intellijthemes.FlatArcDarkOrangeIJTheme;
+import com.formdev.flatlaf.intellijthemes.FlatOneDarkIJTheme;
+import com.formdev.flatlaf.intellijthemes.FlatSolarizedDarkIJTheme;
 import com.formdev.flatlaf.intellijthemes.materialthemeuilite.FlatGitHubDarkIJTheme;
 import com.formdev.flatlaf.intellijthemes.materialthemeuilite.FlatGitHubIJTheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
+import java.awt.Window;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -30,6 +37,13 @@ public class ThemeManager {
         AVAILABLE_THEMES.put("Flat Light", new ThemeInfo(FlatLightLaf.class.getName(), true));
         AVAILABLE_THEMES.put("GitHub Light", new ThemeInfo(FlatGitHubIJTheme.class.getName(), true));
         AVAILABLE_THEMES.put("GitHub Dark", new ThemeInfo(FlatGitHubDarkIJTheme.class.getName(), true));
+
+        // Additional dark theme candidates — higher-contrast alternatives to GitHub Dark
+        AVAILABLE_THEMES.put("Flat Dark", new ThemeInfo(FlatDarkLaf.class.getName(), true));
+        AVAILABLE_THEMES.put("Darcula", new ThemeInfo(FlatDarculaLaf.class.getName(), true));
+        AVAILABLE_THEMES.put("One Dark", new ThemeInfo(FlatOneDarkIJTheme.class.getName(), true));
+        AVAILABLE_THEMES.put("Arc Dark Orange", new ThemeInfo(FlatArcDarkOrangeIJTheme.class.getName(), true));
+        AVAILABLE_THEMES.put("Solarized Dark", new ThemeInfo(FlatSolarizedDarkIJTheme.class.getName(), true));
     }
 
     /**
@@ -49,7 +63,25 @@ public class ThemeManager {
             return false;
         }
 
+        // Only FlatLaf targets get the snapshot/crossfade treatment — it relies on FlatLaf's
+        // own repaint hooks. This is the isFlatLaf flag's real job: gate the animation, since
+        // both branches below otherwise apply the theme the same way.
+        boolean animate = themeInfo.isFlatLaf;
+        if (animate) {
+            FlatAnimatedLafChange.showSnapshot();
+        }
+
         try {
+            LookAndFeel currentLaf = UIManager.getLookAndFeel();
+            if (currentLaf != null && currentLaf.getName().contains("Nimbus")) {
+                // Nimbus leaves lazily-evaluated DerivedColor/painter defaults in the
+                // UIManager defaults table that survive setLookAndFeel() and bleed into
+                // whatever LaF follows — not just FlatLaf targets. Key this on "leaving
+                // Nimbus", and flush by installing a plain intermediate LaF and refreshing
+                // every window before applying the theme actually requested.
+                flushStaleNimbusDefaults();
+            }
+
             if (themeInfo.isFlatLaf) {
                 // Instantiate by class name — works for all FlatLaf and IntelliJ themes
                 LookAndFeel laf = (LookAndFeel) Class.forName(themeInfo.className)
@@ -60,11 +92,53 @@ public class ThemeManager {
                 // Standard Swing LaF
                 UIManager.setLookAndFeel(themeInfo.className);
             }
+
+            // Refresh every open window, including dialogs like the Configuration dialog
+            // itself, so the switch takes effect live. Windows that aren't displayable yet
+            // (e.g. the main frame mid-construction, before its first pack()/setVisible())
+            // are skipped — touching their UI before they have a native peer is what left
+            // stale (0,0) screen-position caches behind, corrupting the first popup/menu.
+            refreshDisplayableWindows();
+
             logger.info("Applied theme: {}", themeName);
             return true;
         } catch (Exception e) {
             logger.error("Failed to apply theme: {}", themeName, e);
             return false;
+        } finally {
+            if (animate) {
+                FlatAnimatedLafChange.hideSnapshotWithAnimation();
+            }
+        }
+    }
+
+    /**
+     * Installs a plain intermediate FlatLaf and flushes it across all open windows to clear
+     * stale Nimbus defaults before the real target theme is applied. If the intermediate
+     * install itself fails, log and fall through — the normal apply below still runs.
+     */
+    private static void flushStaleNimbusDefaults() {
+        try {
+            UIManager.setLookAndFeel(new FlatDarkLaf());
+            refreshDisplayableWindows();
+        } catch (Exception e) {
+            logger.warn("Failed to flush stale Nimbus defaults via intermediate LaF; proceeding with direct theme switch", e);
+        }
+    }
+
+    /**
+     * Updates the UI of every open, displayable window. Windows that aren't displayable yet
+     * (no native peer — e.g. before their first pack()/setVisible()) are skipped: refreshing
+     * them prematurely is what corrupted the first popup/menu position after theme switches.
+     */
+    private static void refreshDisplayableWindows() {
+        for (Window window : Window.getWindows()) {
+            if (!window.isDisplayable()) {
+                continue;
+            }
+            SwingUtilities.updateComponentTreeUI(window);
+            window.revalidate();
+            window.repaint();
         }
     }
 


### PR DESCRIPTION
## Summary
- Registers five new dark theme candidates (Flat Dark, Darcula, One Dark, Arc Dark Orange, Solarized Dark) to A/B against GitHub Dark's poor contrast on disabled buttons/secondary text in the credential status table.
- Fixes theme switching to refresh every open window (including the Configuration dialog itself) instead of only the parent frame.
- Fixes visual corruption when switching directly from Nimbus to any other LaF by flushing Nimbus's stale `UIManager` defaults through a plain intermediate LaF first.
- Makes the credential table's `EXPIRED`/`UNKNOWN` status colors theme-aware (read live from `UIManager`/`FlatLaf.isLafDark()`) instead of hardcoded.
- Works around a Linux/X11 timing race where the window manager confirms a window's on-screen position asynchronously after `setVisible(true)`, which could render the first FlatLaf popup (e.g. the File menu) at (0,0) until the window was moved. This surfaced because the DB's default theme name (`"Flat Dark"`) was never actually a registered theme before this PR, so FlatLaf had silently never been active on default installs.

## Test plan
- [x] `mvn clean package` builds and unit tests pass in the project's Docker/Maven container
- [x] Manually verified: Nimbus → One Dark direct, Nimbus → GitHub Dark direct, One Dark → Nimbus → One Dark, theme switch while Configuration dialog is open
- [x] Manually verified: File menu renders correctly positioned on first launch and menu items are clickable

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)