### PR TITLE
Remember last-used profile and add "start minimized to tray" option

### DIFF
--- a/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
+++ b/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
@@ -28,6 +28,7 @@ public class ConfigurationDialog extends JDialog {
     private JComboBox<String> browserComboBox;
     private JCheckBox useFastPassCheckBox;
     private JCheckBox trayNotificationsCheckBox;
+    private JCheckBox startMinimizedCheckBox;
     private JButton saveButton;
     private JButton cancelButton;
 
@@ -61,6 +62,7 @@ public class ConfigurationDialog extends JDialog {
         outerGbc.gridy = 3; outerPanel.add(buildBrowserSection(), outerGbc);
         outerGbc.gridy = 4; outerPanel.add(buildAuthSection(), outerGbc);
         outerGbc.gridy = 5; outerPanel.add(buildNotificationsSection(), outerGbc);
+        outerGbc.gridy = 6; outerPanel.add(buildStartupSection(), outerGbc);
 
         add(outerPanel, BorderLayout.CENTER);
 
@@ -194,6 +196,23 @@ public class ConfigurationDialog extends JDialog {
         return panel;
     }
 
+    private JPanel buildStartupSection() {
+        JPanel panel = titledPanel("Startup");
+        GridBagConstraints gbc = sectionGbc();
+
+        gbc.gridx = 0; gbc.gridy = 0; gbc.gridwidth = 2;
+        startMinimizedCheckBox = new JCheckBox("Start minimized to tray");
+        startMinimizedCheckBox.setMnemonic(KeyEvent.VK_M);
+        boolean traySupported = SystemTray.isSupported();
+        startMinimizedCheckBox.setEnabled(traySupported);
+        startMinimizedCheckBox.setToolTipText(traySupported
+            ? "Skip showing the main window on launch; the app starts hidden in the system tray"
+            : "System tray is not available on this platform/environment");
+        panel.add(startMinimizedCheckBox, gbc);
+
+        return panel;
+    }
+
     private static JPanel titledPanel(String title) {
         JPanel panel = new JPanel(new GridBagLayout());
         panel.setBorder(BorderFactory.createTitledBorder(title));
@@ -249,6 +268,8 @@ public class ConfigurationDialog extends JDialog {
 
         trayNotificationsCheckBox.setSelected(databaseManager.getTrayNotificationsEnabled());
 
+        startMinimizedCheckBox.setSelected(databaseManager.getStartMinimizedToTray());
+
         updatePasswordExpirationEnabled();
     }
 
@@ -278,8 +299,11 @@ public class ConfigurationDialog extends JDialog {
                 boolean trayNotificationsEnabled = trayNotificationsCheckBox.isSelected();
                 databaseManager.setTrayNotificationsEnabled(trayNotificationsEnabled);
 
-                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, browser = {}, use_fastpass = {}, tray_notifications = {}",
-                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, selectedBrowser, useFastPass, trayNotificationsEnabled);
+                boolean startMinimized = startMinimizedCheckBox.isSelected();
+                databaseManager.setStartMinimizedToTray(startMinimized);
+
+                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, browser = {}, use_fastpass = {}, tray_notifications = {}, start_minimized_to_tray = {}",
+                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, selectedBrowser, useFastPass, trayNotificationsEnabled, startMinimized);
 
                 // Apply theme immediately — ThemeManager refreshes all open windows,
                 // including this dialog, so it re-themes live.

--- a/src/main/java/com/ourgiant/saml/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/DatabaseManager.java
@@ -184,6 +184,25 @@ public class DatabaseManager {
         setConfig("browser", browser);
     }
 
+    // Intentionally not seeded: an absent value means no profile has been used yet,
+    // letting the profile combo box fall back to its default (first alphabetically).
+    public String getLastUsedProfile() {
+        return getConfig("last_used_profile");
+    }
+
+    public void setLastUsedProfile(String profile) {
+        setConfig("last_used_profile", profile);
+    }
+
+    public boolean getStartMinimizedToTray() {
+        String value = getConfig("start_minimized_to_tray");
+        return "true".equalsIgnoreCase(value); // Disabled by default
+    }
+
+    public void setStartMinimizedToTray(boolean enabled) {
+        setConfig("start_minimized_to_tray", String.valueOf(enabled));
+    }
+
     // Token state methods
     public void updateExpiration(String profileName, Instant expiration) {
         if (profileName == null || expiration == null) {

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -50,6 +50,7 @@ public class SwingMain extends JFrame {
     private JProgressBar loginProgressBar;
     private Timer statusRefreshTimer;
     private volatile boolean credentialRequestInProgress = false;
+    private boolean loadingProfiles = false;
 
     private TrayIcon trayIcon;
     private final Map<String, Instant> lastNotifiedExpiration = new HashMap<>();
@@ -101,7 +102,10 @@ public class SwingMain extends JFrame {
         profilePanel.add(selectProfileLabel);
         profileComboBox = new JComboBox<>();
         profileComboBox.setPreferredSize(new Dimension(220, 25));
-        profileComboBox.addActionListener(e -> updateCredentialButtons());
+        profileComboBox.addActionListener(e -> {
+            updateCredentialButtons();
+            saveLastUsedProfile();
+        });
         profileComboBox.setToolTipText("The AWS profile to authenticate and fetch credentials for");
         selectProfileLabel.setLabelFor(profileComboBox);
         profilePanel.add(profileComboBox);
@@ -473,10 +477,15 @@ public class SwingMain extends JFrame {
     }
 
     private void restoreFromTray() {
+        boolean wasVisible = isVisible();
         setVisible(true);
         setExtendedState(JFrame.NORMAL);
         toFront();
         requestFocus();
+        if (!wasVisible) {
+            // First real show when launched minimized skips main()'s post-show fix; apply it here.
+            syncWindowPositionWithWindowManager(this);
+        }
     }
 
     private void exitApplication() {
@@ -620,15 +629,38 @@ public class SwingMain extends JFrame {
     private void loadProfiles() {
         try {
             List<String> profiles = configManager.getAvailableProfiles();
-            profileComboBox.removeAllItems();
-            for (String profile : profiles) {
-                profileComboBox.addItem(profile);
+            String lastUsedProfile = databaseManager.getLastUsedProfile();
+
+            // JComboBox auto-selects the first added item, firing the selection listener
+            // before the real last-used profile can be restored below; suppress persistence
+            // during this programmatic rebuild so that transient selection doesn't clobber it.
+            loadingProfiles = true;
+            try {
+                profileComboBox.removeAllItems();
+                for (String profile : profiles) {
+                    profileComboBox.addItem(profile);
+                }
+                if (lastUsedProfile != null && profiles.contains(lastUsedProfile)) {
+                    profileComboBox.setSelectedItem(lastUsedProfile);
+                }
+            } finally {
+                loadingProfiles = false;
             }
         } catch (Exception e) {
             JOptionPane.showMessageDialog(this,
                 "Error loading profiles: " + e.getMessage(),
                 "Configuration Error",
                 JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void saveLastUsedProfile() {
+        if (loadingProfiles) {
+            return;
+        }
+        String selectedProfile = (String) profileComboBox.getSelectedItem();
+        if (selectedProfile != null) {
+            databaseManager.setLastUsedProfile(selectedProfile);
         }
     }
 
@@ -955,8 +987,11 @@ public class SwingMain extends JFrame {
             }
 
             SwingMain mainWindow = new SwingMain();
-            mainWindow.setVisible(true);
-            syncWindowPositionWithWindowManager(mainWindow);
+            boolean startMinimized = mainWindow.trayIcon != null && mainWindow.databaseManager.getStartMinimizedToTray();
+            if (!startMinimized) {
+                mainWindow.setVisible(true);
+                syncWindowPositionWithWindowManager(mainWindow);
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- `DatabaseManager`: adds `getLastUsedProfile()`/`setLastUsedProfile()` (unseeded, like `browser`) and `getStartMinimizedToTray()`/`setStartMinimizedToTray()` (defaults false, like `tray_notifications_enabled`).
- `SwingMain`: persists the profile combo box selection on every change and restores it in `loadProfiles()` on startup instead of always defaulting to the first profile alphabetically. `main()` skips `setVisible(true)` at launch when "start minimized to tray" is enabled *and* the tray icon actually initialized (fails safe to showing the window when tray isn't supported). `restoreFromTray()` now applies the existing X11 popup-position fix on first real show, since that can now happen there instead of at launch.
- `ConfigurationDialog`: adds a "Startup" section with a "Start minimized to tray" checkbox, gated on `SystemTray.isSupported()` the same way the existing tray-notifications checkbox is.

Did not add a CLI launch-flag alternative — the issue offered "Settings, or a launch flag" and the Settings toggle covers the requirement.

## Verification
Ran the actual built jar end-to-end (not unit tests) against an isolated fake `$HOME` with a two-profile `samlsts` file, driving the real `SwingMain`/`ConfigurationDialog` classes through their real Swing component APIs and real SQLite-backed `DatabaseManager`:
- Selected a non-default profile in a live session → confirmed it persisted to the on-disk SQLite `config` table.
- Constructed a fresh `SwingMain` (simulating a relaunch) → combo box now pre-selects the persisted profile instead of the alphabetically-first one.
- **This caught a real bug**: `JComboBox` auto-selects the first item as it's added, which fired the new selection-persistence listener *before* the real last-used value could be restored, silently overwriting the correct DB value with the wrong one on every single launch. Fixed with a `loadingProfiles` guard flag that suppresses persistence during the programmatic rebuild in `loadProfiles()`. Re-ran the same scenario after the fix and confirmed the persisted value now survives a relaunch.
- Verified the "start minimized" DB flag round-trips through `ConfigurationDialog`, and that `SwingMain.main()` fails safe (still shows the window) when the tray isn't supported, by actually running the real `main()` entry point.
- Could not capture screenshots — this dev environment's Wayland compositor blocks legacy X11 `Robot` screen capture (confirmed with a full-screen capture test, also all-black) — so this was verified via the app's real live component state and on-disk DB contents rather than pixels. Also couldn't visually confirm tray-hidden behavior since system tray isn't supported at all in this sandbox; the fail-safe path (window still shows) was verified instead.

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)