### PR TITLE
Guard against an unusably small main window

### DIFF
--- a/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
+++ b/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
@@ -41,6 +41,7 @@ public class ConfigurationDialog extends JDialog {
         initializeUI();
         loadCurrentSettings();
         pack();
+        setMinimumSize(getSize());
         setLocationRelativeTo(parent);
     }
 

--- a/src/main/java/com/ourgiant/saml/CredentialsDialog.java
+++ b/src/main/java/com/ourgiant/saml/CredentialsDialog.java
@@ -28,6 +28,7 @@ public class CredentialsDialog extends JDialog {
 
         initializeUI();
         pack();
+        setMinimumSize(getSize());
         setLocationRelativeTo(parent);
     }
 

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -227,6 +227,7 @@ public class SwingMain extends JFrame {
         add(statusPanel, BorderLayout.SOUTH);
 
         pack();
+        setMinimumSize(getSize());
         setLocationRelativeTo(null);
     }
 


### PR DESCRIPTION
## Summary
- Adds `setMinimumSize(getSize())` right after `pack()` in `SwingMain`, `ConfigurationDialog`, and `CredentialsDialog` — these were the three gaps. Rather than a hardcoded magic-number floor, this locks each window's minimum to whatever size its own layout just computed as necessary, so the floor stays correct automatically as controls are added/removed later.
- Audited every `JFrame`/`JDialog` in the app (six total): `ProfileManagerDialog`, `ProfileEditDialog`, and `FirstRunSetupDialog` already had an equivalent guard from prior work; no changes needed there.

## Verification
Ran the actual built jar (not unit tests) against a live X11 display, driving the real `SwingMain`, `ConfigurationDialog`, and `CredentialsDialog` classes:
- Read each window's `getMinimumSize()` after construction, then called `setSize(...)` with a deliberately tiny value (50×50 / 10×10) to simulate a user dragging the window far below its floor.
- Confirmed via `getSize()` that AWT clamped every window back to its minimum — none could be shrunk below the size needed to show its controls.
- One thing worth noting from the run: right after `setVisible(true)`, `getSize()` briefly reported a size a bit smaller than the just-set minimum before settling to the enforced floor a few hundred ms later — this is the same class of asynchronous window-manager decoration/geometry negotiation this codebase already documents for X11 window positioning (see `syncWindowPositionWithWindowManager`), not a gap in the guard. Confirmed by re-running with a longer settle delay before the first read: sizes matched the minimum exactly with no transient dip.
- Could not capture screenshots — this sandbox's Wayland compositor blocks legacy X11 `Robot` screen capture — so this was verified via the real windows' actual `Dimension` state rather than pixels.

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)