### PR TITLE
Categorize credential-request failures and add in-dialog Retry

### DIFF
--- a/src/main/java/com/ourgiant/saml/CredentialRequestError.java
+++ b/src/main/java/com/ourgiant/saml/CredentialRequestError.java
@@ -1,0 +1,155 @@
+package com.ourgiant.saml;
+
+import org.openqa.selenium.NoSuchWindowException;
+import org.openqa.selenium.TimeoutException;
+import software.amazon.awssdk.services.sts.model.ExpiredTokenException;
+import software.amazon.awssdk.services.sts.model.IdpCommunicationErrorException;
+import software.amazon.awssdk.services.sts.model.StsException;
+
+import javax.swing.*;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Categorizes a credential-request failure so the error dialog can show failure-specific
+ * guidance and only offer Retry when retrying is actually likely to help.
+ */
+public class CredentialRequestError {
+
+    public enum Category {
+        TRANSIENT,
+        CONFIGURATION,
+        USER_CANCELLED,
+        UNKNOWN
+    }
+
+    private final Category category;
+    private final String title;
+    private final String guidance;
+    private final String detail;
+    private final boolean retryable;
+    private final int iconMessageType;
+
+    private CredentialRequestError(Category category, String title, String guidance, String detail,
+                                    boolean retryable, int iconMessageType) {
+        this.category = category;
+        this.title = title;
+        this.guidance = guidance;
+        this.detail = detail;
+        this.retryable = retryable;
+        this.iconMessageType = iconMessageType;
+    }
+
+    public static CredentialRequestError classify(Throwable error) {
+        Throwable root = unwrapExecutionException(error);
+        String message = root.getMessage() != null ? root.getMessage() : root.toString();
+
+        if (findCause(root, NoSuchWindowException.class) != null
+                || message.contains("Password entry cancelled by user")) {
+            return new CredentialRequestError(Category.USER_CANCELLED, "Login Cancelled",
+                "The login was cancelled before it could finish.",
+                message, true, JOptionPane.INFORMATION_MESSAGE);
+        }
+
+        StsException stsError = findCause(root, StsException.class);
+        if (stsError != null) {
+            if (stsError instanceof IdpCommunicationErrorException || stsError instanceof ExpiredTokenException) {
+                return new CredentialRequestError(Category.TRANSIENT, "Temporary AWS Error",
+                    "AWS STS had a temporary problem communicating with the identity provider. This is usually transient — you can safely retry.",
+                    message, true, JOptionPane.WARNING_MESSAGE);
+            }
+            return new CredentialRequestError(Category.CONFIGURATION, "AWS Configuration Error",
+                "AWS STS rejected the SAML assertion or role request. Check the IAM role's trust policy and this profile's account/role configuration.",
+                message, false, JOptionPane.ERROR_MESSAGE);
+        }
+
+        if (root instanceof IllegalArgumentException) {
+            return new CredentialRequestError(Category.CONFIGURATION, "Configuration Error",
+                "This profile or SAML provider is missing required configuration.",
+                message, false, JOptionPane.ERROR_MESSAGE);
+        }
+
+        if (containsAny(message, "Matching role not found", "Could not find role element",
+                "SAML Assertion not found", "SAML response not found")) {
+            return new CredentialRequestError(Category.CONFIGURATION, "SAML Configuration Error",
+                "The identity provider didn't return a role matching this profile's account/role configuration. Check the profile and the IdP's role mapping.",
+                message, false, JOptionPane.ERROR_MESSAGE);
+        }
+
+        if (containsAny(message, "MFA push selection", "FastPass selection")) {
+            return new CredentialRequestError(Category.TRANSIENT, "Login Timed Out",
+                "The MFA/FastPass prompt didn't appear in time. This can happen with a slow connection, an unapproved push, "
+                    + "or an incorrect password on the previous screen. You can safely retry.",
+                message, true, JOptionPane.WARNING_MESSAGE);
+        }
+
+        if (findCause(root, TimeoutException.class) != null) {
+            return new CredentialRequestError(Category.TRANSIENT, "Login Timed Out",
+                "A step in the login flow took too long, most likely due to a slow connection or IdP page load. You can safely retry.",
+                message, true, JOptionPane.WARNING_MESSAGE);
+        }
+
+        return new CredentialRequestError(Category.UNKNOWN, "Authentication Error",
+            "An unexpected error occurred while requesting credentials.",
+            message, true, JOptionPane.ERROR_MESSAGE);
+    }
+
+    private static Throwable unwrapExecutionException(Throwable t) {
+        Throwable current = t;
+        while (current instanceof ExecutionException && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Throwable> T findCause(Throwable t, Class<T> type) {
+        Throwable current = t;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return (T) current;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    private static boolean containsAny(String haystack, String... needles) {
+        for (String needle : needles) {
+            if (haystack.contains(needle)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Category category() {
+        return category;
+    }
+
+    public boolean retryable() {
+        return retryable;
+    }
+
+    public String title() {
+        return title;
+    }
+
+    public int iconMessageType() {
+        return iconMessageType;
+    }
+
+    public String htmlMessage() {
+        return "<html><body style='width: 320px'>"
+            + "<p>" + escapeHtml(guidance) + "</p>"
+            + "<p style='color: gray; font-size: 90%;'>" + escapeHtml(detail) + "</p>"
+            + "</body></html>";
+    }
+
+    public String statusMessage() {
+        return title + ": " + detail;
+    }
+
+    private static String escapeHtml(String s) {
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+}

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -719,15 +719,37 @@ public class SwingMain extends JFrame {
                         "Success",
                         JOptionPane.INFORMATION_MESSAGE);
                 } catch (Exception ex) {
-                    statusLabel.setText("Error obtaining credentials: " + ex.getMessage());
-                    JOptionPane.showMessageDialog(SwingMain.this,
-                        "Error obtaining credentials: " + ex.getMessage(),
-                        "Authentication Error",
-                        JOptionPane.ERROR_MESSAGE);
+                    CredentialRequestError error = CredentialRequestError.classify(ex);
+                    statusLabel.setText(error.statusMessage());
+                    showCredentialErrorDialog(selectedProfile, error);
                 }
             }
         };
         worker.execute();
+    }
+
+    private void showCredentialErrorDialog(String selectedProfile, CredentialRequestError error) {
+        if (error.retryable()) {
+            Object[] options = {"Retry", "Close"};
+            int choice = JOptionPane.showOptionDialog(
+                this,
+                error.htmlMessage(),
+                error.title(),
+                JOptionPane.DEFAULT_OPTION,
+                error.iconMessageType(),
+                null,
+                options,
+                options[0]
+            );
+            if (choice == 0) {
+                requestCredentialsForProfile(selectedProfile);
+            }
+        } else {
+            JOptionPane.showMessageDialog(this,
+                error.htmlMessage(),
+                error.title(),
+                error.iconMessageType());
+        }
     }
 
     private static class StatusTableCellRenderer extends DefaultTableCellRenderer {


### PR DESCRIPTION
## Summary
- New `CredentialRequestError.classify(Throwable)` walks the exception's cause chain and buckets it into one of four categories: `TRANSIENT`, `CONFIGURATION`, `USER_CANCELLED`, `UNKNOWN`. Classification is based on:
  - Typed exceptions where available: Selenium `NoSuchWindowException` (browser closed by the user → cancelled), and the actual AWS STS SDK exception types (`IdpCommunicationErrorException`/`ExpiredTokenException` → transient; other `StsException` subtypes like `RegionDisabledException` → configuration) — these are reachable via `getCause()` without touching `SamlAuthenticator`'s STS catch block, since it already wraps-and-rethrows with the original typed exception as cause.
  - `IllegalArgumentException` (the profile/provider config validation throws in `SamlAuthenticator`) → configuration.
  - Message-pattern matching against the exact strings from every other throw site I found in `BrowserLoginHandler`/`SamlAuthenticator`/`SamlParser` (role-not-found, SAML-response-not-found, MFA/FastPass-selection-timeout, password-prompt-cancelled).
  - Falls back to: any `TimeoutException` in the chain → transient; otherwise → unknown (still retryable, since retrying an unrecognized error is harmless).
- `SwingMain`'s credential-request error handler now calls `classify()` and shows a dialog with a category-specific title, icon, and guidance message. A "Retry" button (which re-invokes `requestCredentialsForProfile`) only appears when the category is actually likely to benefit from retrying — configuration errors get a Close-only dialog instead, since retrying without fixing the profile/role/trust-policy would just fail identically.
- Didn't add a dedicated custom exception hierarchy or touch any throw sites in `BrowserLoginHandler`/`SamlAuthenticator` — classification is entirely additive at the dialog layer, so the actual login/STS flow is untouched. I considered adding Selenium DOM detection for "wrong password" specifically (Okta's inline error banner), but couldn't verify the CSS selector against a real Okta tenant and it would add ~5s of latency to every successful login while probing for it, so I left that out; the MFA/FastPass-timeout guidance text now mentions an incorrect password as one possible cause instead.

## Verification
Ran the actual built jar (not unit tests) against the real `CredentialRequestError.classify()` and the real `SwingMain` dialog:
- Fed `classify()` 11 exception shapes built to match every throw site identified in `BrowserLoginHandler`/`SamlAuthenticator`/`SamlParser` (MFA timeout, FastPass timeout, password-cancelled, browser-window-closed, incomplete profile config, SAML role-not-found x2, and 3 real AWS SDK STS exception types) — all classified into the expected category with the expected retryable flag.
- Invoked the real (private) `showCredentialErrorDialog` on a live `SwingMain` instance via reflection (same as calling it from the real catch block) and interacted with the actual on-screen dialog: confirmed a transient error shows both "Retry" and "Close" buttons, and a configuration error shows only "Close" (no Retry).
- Clicked the real "Retry" button (`JButton.doClick()`) and confirmed via the app's own log output that it genuinely re-invoked `requestCredentialsForProfile` — a fresh `"Starting credential request for profile: ..."` log line appears immediately after the click, not just a dialog dismissal.
- Could not exercise a real end-to-end Okta login (no test IdP/browser driver available in this sandbox) or capture screenshots (Wayland blocks legacy X11 `Robot` capture here), so verification relied on the classifier's real logic plus live Swing component/log state rather than a full browser-driven login or pixels.

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)