### PR TITLE
Bump version from 1.1.0 to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>


### PR DESCRIPTION
## Summary
Minor version bump covering this session's merged work:
- #72 — Fix application icon for Linux and Windows packaged launcher
- #73 — Remember last-used profile and add a "start minimized to tray" launch option
- #74 — Guard against an unusably small main window and dialogs
- #75 — Categorize credential-request error handling and add in-dialog Retry
- #76 — Add sortable columns and a name filter to the credential status table

No functional changes beyond the `pom.xml` version bump — `version.properties` is populated from `project.version` via Maven resource filtering at build time, so no other files need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)