### PR TITLE
Add macOS build support to the release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,8 +102,64 @@ jobs:
           name: linux-artifacts
           path: installer-output/*.deb
 
+  build-macos:
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x64
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 24
+        uses: actions/setup-java@v4
+        with:
+          java-version: '24'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build with Maven
+        run: mvn package
+
+      - name: Get version from pom.xml
+        if: startsWith(github.ref, 'refs/tags/v')
+        id: version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+
+      # TODO: no .icns icon exists yet in src/packaging/ (only app-icon.ico, for Windows) — generate
+      # one from src/main/resources/saml_swing_icon_small.png and pass --icon here once it exists.
+      - name: Create .dmg with jpackage
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          jpackage \
+            --input target/ \
+            --main-jar aws-idp-saml-ui-all.jar \
+            --main-class com.ourgiant.saml.SwingMain \
+            --name "AWS IDP SAML" \
+            --app-version ${{ steps.version.outputs.version }} \
+            --vendor OurGiant \
+            --type dmg \
+            --dest installer-output
+
+      - name: Rename dmg for this architecture
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          cd installer-output
+          mv *.dmg "AWS-IDP-SAML-${{ steps.version.outputs.version }}-${{ matrix.arch }}.dmg"
+
+      - name: Upload macOS artifacts
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-artifacts-${{ matrix.arch }}
+          path: installer-output/*.dmg
+
   release:
-    needs: [ build-windows, build-linux ]
+    needs: [ build-windows, build-linux, build-macos ]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- New `build-macos` job, matrixed over `macos-latest`/`arm64` and `macos-15-intel`/`x64`, alongside the existing `build-windows`/`build-linux` jobs.
- On tag pushes, packages a `.dmg` via jpackage, renames it to `AWS-IDP-SAML-<version>-<arch>.dmg` so the two matrix legs don't collide, and uploads it as `macos-artifacts-<arch>` for the `release` job to pick up.
- No `.icns` icon exists yet (`src/packaging/` only has `app-icon.ico`, added for Windows). macOS jpackage specifically requires `.icns` — can't reuse the `.ico`/`.png`. Omitted `--icon` for now with a `TODO` comment rather than attempting a blind conversion in CI.
- Unsigned, not notarized — matches the existing Windows/Linux jobs, which are also unsigned.
- `release` job's `needs:` now includes `build-macos`. Its artifact-download step already used `merge-multiple: true`, so no other changes were needed there — confirmed by reading the job, not just assuming it.
- Didn't touch the Windows or Linux jobs.

## Verification
- Validated the YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`) and confirmed via direct inspection that `jobs` includes all four expected job names, `release.needs` lists all three build jobs, and the matrix expands to the two expected runner/arch pairs.
- The `.dmg` packaging/upload steps are gated behind `refs/tags/v*`, so they can't be exercised by a normal PR — only a real tag push runs them, and I'm not creating a release tag as part of filing this PR. What *does* run on this PR, on real `macos-latest`/`macos-15-intel` GitHub-hosted runners, is `mvn package` — worth watching those two checks pass here as the actual verification for this PR, since that at least confirms JDK 24/Maven setup and the build itself work on macOS. Recommend a maintainer watch the first tagged build closely for the jpackage/dmg step specifically, since that part is genuinely unverified until then.

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)