### PR TITLE
Fix status table context menu acting on the wrong profile

### DIFF
--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -59,6 +59,7 @@ public class SwingMain extends JFrame {
     private SwingWorker<Void, Void> activeCredentialWorker;
     private boolean credentialRequestCancelledByUser = false;
     private boolean loadingProfiles = false;
+    private String contextMenuTargetProfile;
 
     private TrayIcon trayIcon;
     private final Map<String, Instant> lastNotifiedExpiration = new HashMap<>();
@@ -202,6 +203,10 @@ public class SwingMain extends JFrame {
                 }
                 tokenStatusTable.setRowSelectionInterval(row, row);
                 String profile = (String) tokenStatusTableModel.getValueAt(tokenStatusTable.convertRowIndexToModel(row), 0);
+                // The dropdown can't reflect profiles that only exist via saved credentials/token
+                // state (not defined in samlsts) — setSelectedItem silently no-ops for those. Track
+                // the right-clicked profile directly so menu actions always target the right row.
+                contextMenuTargetProfile = profile;
                 profileComboBox.setSelectedItem(profile);
                 tableContextMenu.show(tokenStatusTable, e.getX(), e.getY());
             }
@@ -871,31 +876,31 @@ public class SwingMain extends JFrame {
         JPopupMenu menu = new JPopupMenu();
 
         JMenuItem requestItem = new JMenuItem("Request Credentials");
-        requestItem.addActionListener(e -> requestCredentialsForProfile((String) profileComboBox.getSelectedItem()));
+        requestItem.addActionListener(e -> requestCredentialsForProfile(contextMenuTargetProfile));
         menu.add(requestItem);
 
         JMenuItem showItem = new JMenuItem("Show Credentials");
-        showItem.addActionListener(e -> showCredentialsDialogForProfile((String) profileComboBox.getSelectedItem(), false, true));
+        showItem.addActionListener(e -> showCredentialsDialogForProfile(contextMenuTargetProfile, false, true));
         menu.add(showItem);
 
         JMenuItem showEncryptedItem = new JMenuItem("Show Encrypted Credentials");
-        showEncryptedItem.addActionListener(e -> showCredentialsDialogForProfile((String) profileComboBox.getSelectedItem(), true, false));
+        showEncryptedItem.addActionListener(e -> showCredentialsDialogForProfile(contextMenuTargetProfile, true, false));
         menu.add(showEncryptedItem);
 
         JMenuItem openConsoleItem = new JMenuItem("Open Console");
-        openConsoleItem.addActionListener(e -> openAwsConsoleForProfile((String) profileComboBox.getSelectedItem()));
+        openConsoleItem.addActionListener(e -> openAwsConsoleForProfile(contextMenuTargetProfile));
         menu.add(openConsoleItem);
 
         menu.addSeparator();
 
         JMenuItem deleteItem = new JMenuItem("Delete Profile...");
-        deleteItem.addActionListener(e -> deleteProfileFromContextMenu((String) profileComboBox.getSelectedItem()));
+        deleteItem.addActionListener(e -> deleteProfileFromContextMenu(contextMenuTargetProfile));
         menu.add(deleteItem);
 
         menu.addPopupMenuListener(new javax.swing.event.PopupMenuListener() {
             @Override
             public void popupMenuWillBecomeVisible(javax.swing.event.PopupMenuEvent e) {
-                String profile = (String) profileComboBox.getSelectedItem();
+                String profile = contextMenuTargetProfile;
                 boolean hasCredentials = profile != null && credentialManager.getCredentials(profile) != null;
                 java.nio.file.Path publicKeyPath = java.nio.file.Paths.get(System.getProperty("user.home"), ".aws", "public_key.pem");
                 boolean hasPublicKey = java.nio.file.Files.exists(publicKeyPath);


### PR DESCRIPTION
## Summary
Every action in the status table's right-click context menu (Request Credentials, Show Credentials, Show Encrypted Credentials, Open Console, Delete Profile) read its target profile from `profileComboBox.getSelectedItem()` instead of the row that was actually right-clicked.

## Root cause
The existing code tries to keep the dropdown in sync by calling `profileComboBox.setSelectedItem(profile)` right before showing the context menu — but that silently no-ops when the given profile isn't a valid item in the dropdown's list. The dropdown's items come only from `configManager.getAvailableProfiles()` (profiles defined in `samlsts`), while the status table's rows come from a wider union that also includes profiles with saved credentials or token state (`credentialManager.getAllProfileNames()`, `tokenStateManager.getAllExpirations()`). A profile that's present in the table via saved credentials but no longer (or never) defined in `samlsts` reproduces this reliably: right-clicking its row leaves the dropdown, and every context-menu action, pointed at whatever profile was previously selected — exactly what was reported against the 1.2.0 release with Delete Profile.

## Fix
Added `contextMenuTargetProfile`, set directly from the right-clicked row when the context menu is shown, and routed all five context-menu actions (plus the enable/disable logic in `popupMenuWillBecomeVisible`) through it instead of the dropdown's selection. The dropdown's own selection is still updated for the normal case (as a UX convenience so it visibly reflects what you clicked when possible), but the menu's own actions no longer depend on that update having actually taken effect.

## Verification
Ran the actual built jar (not unit tests) against a live X11 display, driving the real `SwingMain` window with a right-clicked-row-vs-dropdown-selection mismatch reproduced concretely:
- Set up two profiles in a fake `samlsts` (`alpha-profile`, `zebra-profile`) plus a third, `orphan-profile`, that only exists via a saved-credentials entry (not in `samlsts` at all) — reproducing the exact "present in the table, absent from the dropdown" condition that triggers the bug.
- **Before the fix**: dispatched a real right-click `MouseEvent` at `orphan-profile`'s row, clicked "Delete Profile..." in the resulting real `JPopupMenu`, and captured the real confirmation dialog's text — it read *"Delete profile "alpha-profile"?"* (the stale dropdown selection), confirming the exact bug reported in the field.
- **After the fix**: same steps, same dialog — now correctly reads *"Delete profile "orphan-profile"?"*.
- Also verified "Request Credentials" on the same orphaned row: before, it would have silently acted on the wrong profile; after, the real `CredentialRequestError` configuration-error dialog correctly names `orphan-profile` in its detail text ("Incomplete profile configuration for: orphan-profile") — confirming the fix generalizes across all five context-menu actions, not just Delete.
- Regression-checked the normal case (right-clicking a profile that *is* in the dropdown) still works correctly, both before and after the fix.
- One harness note for anyone building on this: my first attempt at driving the confirmation dialog deadlocked (`SwingUtilities.invokeAndWait` on a click that opens a *modal* `JOptionPane` blocks forever, since the modal's nested event pump won't return until something dismisses it, which can't happen from the same blocked thread) — switched to `invokeLater` + polling for the dialog instead.

Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)