### PR TITLE
Fix orphaned browser process when cancelling a credential request

### DIFF
--- a/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
@@ -8,7 +8,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.time.Duration;
+import java.util.concurrent.CancellationException;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Handles browser automation for SAML login
@@ -25,10 +28,11 @@ public class BrowserLoginHandler {
     private final String accountNumber;
     private final String iamRole;
     private final Consumer<String> statusCallback;
+    private final BooleanSupplier cancelled;
 
     public BrowserLoginHandler(WebDriver driver, boolean useOktaFastPass, PasswordManager passwordManager,
                                 boolean showBrowser, String accountNumber, String iamRole,
-                                Consumer<String> statusCallback) {
+                                Consumer<String> statusCallback, BooleanSupplier cancelled) {
         this.driver = driver;
         this.wait = new WebDriverWait(driver, Duration.ofSeconds(30));
         this.useOktaFastPass = useOktaFastPass;
@@ -37,6 +41,20 @@ public class BrowserLoginHandler {
         this.accountNumber = accountNumber;
         this.iamRole = iamRole;
         this.statusCallback = statusCallback;
+        this.cancelled = cancelled;
+    }
+
+    // Every wait.until(...) call in this class should go through here instead of calling it
+    // directly. Checking the cancellation flag before evaluating the real condition lets a
+    // cancelled request fail within one poll interval, without needing Thread.interrupt() — which
+    // was tried first and left the browser process orphaned (see SamlAuthenticator.cancel()).
+    private <V> V until(WebDriverWait waitInstance, Function<WebDriver, V> condition) {
+        return waitInstance.until(driver -> {
+            if (cancelled.getAsBoolean()) {
+                throw new CancellationException("Login cancelled");
+            }
+            return condition.apply(driver);
+        });
     }
 
     /**
@@ -50,7 +68,7 @@ public class BrowserLoginHandler {
             driver.get(loginUrl);
 
             statusCallback.accept("Waiting for login page to load...");
-            wait.until(ExpectedConditions.titleContains(loginTitle));
+            until(wait, ExpectedConditions.titleContains(loginTitle));
 
             return handleOktaLogin(username);
 
@@ -78,11 +96,11 @@ public class BrowserLoginHandler {
         // Wait for and fill username field
         try {
             statusCallback.accept("Entering username: " + username + "...");
-            WebElement usernameField = wait.until(ExpectedConditions.elementToBeClickable(By.name("identifier")));
+            WebElement usernameField = until(wait, ExpectedConditions.elementToBeClickable(By.name("identifier")));
             usernameField.clear();
             usernameField.sendKeys(username);
 
-            WebElement nextButton = wait.until(ExpectedConditions.elementToBeClickable(By.className("button-primary")));
+            WebElement nextButton = until(wait, ExpectedConditions.elementToBeClickable(By.className("button-primary")));
             nextButton.click();
         } catch (TimeoutException e) {
             logger.info("Okta username field not found; checking for managed-device MFA flow");
@@ -104,13 +122,13 @@ public class BrowserLoginHandler {
         }
 
         try {
-            WebElement passwordField = wait.until(ExpectedConditions.elementToBeClickable(By.name("credentials.passcode")));
+            WebElement passwordField = until(wait, ExpectedConditions.elementToBeClickable(By.name("credentials.passcode")));
             statusCallback.accept("Entering password...");
             String password = promptForPassword();
             passwordField.clear();
             passwordField.sendKeys(password);
 
-            WebElement signInButton = wait.until(ExpectedConditions.elementToBeClickable(By.className("button-primary")));
+            WebElement signInButton = until(wait, ExpectedConditions.elementToBeClickable(By.className("button-primary")));
             signInButton.click();
 
         } catch (TimeoutException e) {
@@ -132,7 +150,7 @@ public class BrowserLoginHandler {
     private boolean isIntermediateVerifificationPage() {
         try {
             WebDriverWait shortWait = new WebDriverWait(driver, Duration.ofSeconds(10));
-            shortWait.until(ExpectedConditions.presenceOfElementLocated(By.linkText("Back to sign in")));
+            until(shortWait, ExpectedConditions.presenceOfElementLocated(By.linkText("Back to sign in")));
         } catch (TimeoutException e) {
             logger.info("Not on intermediate verification page");
             return false;
@@ -141,7 +159,7 @@ public class BrowserLoginHandler {
         try {
             // Wait for the page to stabilise after detecting the intermediate screen
             WebDriverWait shortWait = new WebDriverWait(driver, Duration.ofSeconds(3));
-            shortWait.until(ExpectedConditions.presenceOfElementLocated(By.className("select-factor")));
+            until(shortWait, ExpectedConditions.presenceOfElementLocated(By.className("select-factor")));
             return true;
         } catch (TimeoutException e) {
             return true; // "Back to sign in" was found; treat as intermediate page regardless
@@ -156,7 +174,7 @@ public class BrowserLoginHandler {
             By usePasswordLocator = By.xpath(
                 "//a[@aria-label='Select Password.']" 
             );
-            WebElement usePasswordOption = wait.until(ExpectedConditions.elementToBeClickable(usePasswordLocator));
+            WebElement usePasswordOption = until(wait, ExpectedConditions.elementToBeClickable(usePasswordLocator));
             usePasswordOption.click();
         } catch (TimeoutException e) {
             logger.warn("Could not find option to switch to password entry on intermediate verification page", e);
@@ -166,7 +184,7 @@ public class BrowserLoginHandler {
     private boolean isPreAuthenticatedOktaMfaScreen() {
         try {
             WebDriverWait shortWait = new WebDriverWait(driver, Duration.ofSeconds(10));
-            shortWait.until(ExpectedConditions.presenceOfElementLocated(By.linkText("Back to sign in")));
+            until(shortWait, ExpectedConditions.presenceOfElementLocated(By.linkText("Back to sign in")));
             String pageSource = driver.getPageSource();
             boolean hasMfaIndicator = pageSource.contains("class=\"button select-factor link-button\"");
             return hasMfaIndicator;
@@ -188,7 +206,7 @@ public class BrowserLoginHandler {
             By fastPassLocator = By.xpath(
                 "//a[@aria-label='Select Okta Verify.'] | //a[contains(@aria-label,'Okta Verify')]"
             );
-            WebElement fastPassOption = wait.until(ExpectedConditions.elementToBeClickable(fastPassLocator));
+            WebElement fastPassOption = until(wait, ExpectedConditions.elementToBeClickable(fastPassLocator));
             fastPassOption.click();
         } catch (TimeoutException e) {
             throw new RuntimeException("Could not find Okta FastPass selection button on managed-device login screen", e);
@@ -204,7 +222,7 @@ public class BrowserLoginHandler {
         // First check if autoChallenge is present and checked, which would indicate we can skip clicking the button
         try {
             WebDriverWait probeWait = new WebDriverWait(driver, Duration.ofSeconds(3));
-            WebElement autoChallengeElement = probeWait.until(ExpectedConditions.presenceOfElementLocated(By.name("autoChallenge")));
+            WebElement autoChallengeElement = until(probeWait, ExpectedConditions.presenceOfElementLocated(By.name("autoChallenge")));
             if (autoChallengeElement.isSelected()) {
                 logger.info("Okta auto-challenge is enabled, skipping click");
                 return;
@@ -216,7 +234,7 @@ public class BrowserLoginHandler {
         logger.info("Clicking Okta MFA push selection");
 
         try {
-            WebElement mfaOption = wait.until(ExpectedConditions.elementToBeClickable(selectionLocator));
+            WebElement mfaOption = until(wait, ExpectedConditions.elementToBeClickable(selectionLocator));
             mfaOption.click();
         } catch (TimeoutException e) {
             throw new RuntimeException("Could not find Okta MFA push selection button on managed-device login screen", e);
@@ -225,7 +243,7 @@ public class BrowserLoginHandler {
         // On Windows an extra "Send Push" confirmation page appears after selecting the MFA method; not present on Linux
         try {
             WebDriverWait probeWait = new WebDriverWait(driver, Duration.ofSeconds(5));
-            WebElement sendPushButton = probeWait.until(ExpectedConditions.elementToBeClickable(By.xpath("//input[@class='button button-primary' and @type='submit' and @value='Send push' and @data-type='save']")));
+            WebElement sendPushButton = until(probeWait, ExpectedConditions.elementToBeClickable(By.xpath("//input[@class='button button-primary' and @type='submit' and @value='Send push' and @data-type='save']")));
             sendPushButton.click();
         } catch (TimeoutException e) {
             logger.info("Send Push button not found after clicking Okta Verify selection, which may be expected on some platforms");
@@ -288,15 +306,15 @@ public class BrowserLoginHandler {
         logger.info("Waiting for SAML response...");
 
         statusCallback.accept("Waiting for redirect to AWS sign-in page...");
-        wait.until(ExpectedConditions.urlContains("signin.aws.amazon.com"));
+        until(wait, ExpectedConditions.urlContains("signin.aws.amazon.com"));
 
         statusCallback.accept("Capturing SAML response...");
 
         // Try to find SAML response in form
         String samlResponse = null;
         try {
-            WebElement samlResponseElement = wait.until(
-                ExpectedConditions.presenceOfElementLocated(By.name("SAMLResponse"))
+            WebElement samlResponseElement = until(
+                wait, ExpectedConditions.presenceOfElementLocated(By.name("SAMLResponse"))
             );
 
             samlResponse = samlResponseElement.getAttribute("value");
@@ -349,7 +367,7 @@ public class BrowserLoginHandler {
         );
 
         try {
-            WebElement roleElement = wait.until(ExpectedConditions.elementToBeClickable(By.xpath(roleXpath)));
+            WebElement roleElement = until(wait, ExpectedConditions.elementToBeClickable(By.xpath(roleXpath)));
             roleElement.click();
             logger.info("Role element clicked");
         } catch (TimeoutException e) {

--- a/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
+++ b/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
@@ -31,7 +31,6 @@ public class SamlAuthenticator {
     private final ConfigManager configManager;
     private final CredentialManager credentialManager;
     private final PasswordManager passwordManager;
-    private volatile WebDriver activeDriver;
     private volatile boolean cancelled = false;
 
     public SamlAuthenticator() {
@@ -40,18 +39,14 @@ public class SamlAuthenticator {
         this.passwordManager = new PasswordManager(new DatabaseManager());
     }
 
-    // Best-effort async quit (off-thread so the EDT never blocks on it); the prompt unblock of
-    // an active Selenium wait actually comes from the paired SwingWorker.cancel(true) interrupt
-    // in SwingMain, not this quit() — quitting alone just queues behind an active wait. Known
-    // gap: that interrupt can leave the browser process orphaned even though the UI recovers.
+    // Just sets a flag that BrowserLoginHandler checks between polls of every Selenium wait,
+    // so a blocked wait fails within one poll interval on the SAME thread that's using the
+    // driver — the request thread's own existing exception handling then quits it normally.
+    // Deliberately not Thread.interrupt()-based: that was tried first and reliably left the
+    // browser process orphaned, apparently because interrupting a thread mid-blocking-I/O can
+    // leave the WebDriver's HTTP client unusable for the cleanup quit() that follows.
     public void cancel() {
         cancelled = true;
-        WebDriver driver = activeDriver;
-        if (driver != null) {
-            Thread cleanupThread = new Thread(driver::quit, "cancelled-webdriver-cleanup");
-            cleanupThread.setDaemon(true);
-            cleanupThread.start();
-        }
     }
 
     /**
@@ -127,16 +122,14 @@ public class SamlAuthenticator {
         statusCallback.accept("Launching browser...");
 
         WebDriver driver = createWebDriver(showBrowser);
-        activeDriver = driver;
         try {
             BrowserLoginHandler loginHandler = new BrowserLoginHandler(driver, useOktaFastPass, passwordManager,
-                    showBrowser, accountNumber, iamRole, statusCallback);
+                    showBrowser, accountNumber, iamRole, statusCallback, () -> cancelled);
             return loginHandler.performLogin(loginUrl, loginTitle, username);
         } catch (Exception e) {
             driver.quit();
             throw e;
         } finally {
-            activeDriver = null;
             if (!showBrowser) {
                 driver.quit();
             }

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -56,7 +56,6 @@ public class SwingMain extends JFrame {
     private Timer statusRefreshTimer;
     private volatile boolean credentialRequestInProgress = false;
     private SamlAuthenticator activeAuthenticator;
-    private SwingWorker<Void, Void> activeCredentialWorker;
     private boolean credentialRequestCancelledByUser = false;
     private boolean loadingProfiles = false;
     private String contextMenuTargetProfile;
@@ -766,7 +765,6 @@ public class SwingMain extends JFrame {
                 credentialRequestInProgress = false;
                 loginProgressBar.setVisible(false);
                 activeAuthenticator = null;
-                activeCredentialWorker = null;
 
                 if (credentialRequestCancelledByUser) {
                     statusLabel.setText("Credential request cancelled for profile: " + selectedProfile);
@@ -789,7 +787,6 @@ public class SwingMain extends JFrame {
                 }
             }
         };
-        activeCredentialWorker = worker;
         worker.execute();
     }
 
@@ -798,9 +795,6 @@ public class SwingMain extends JFrame {
         credentialRequestCancelledByUser = true;
         if (activeAuthenticator != null) {
             activeAuthenticator.cancel();
-        }
-        if (activeCredentialWorker != null) {
-            activeCredentialWorker.cancel(true);
         }
     }
 


### PR DESCRIPTION
## Summary
#79 shipped credential-request cancellation using `SwingWorker.cancel(true)` to interrupt the request thread and unblock Selenium's waits. It reliably recovered the UI promptly, but — as documented in #79's own code comments and PR description, and tracked here in #84 — left the browser process orphaned in every case tested, even though the *natural* (non-cancelled, timed-out) failure path reliably quit the same driver every time via the exact same cleanup code.

## Root cause
Interrupting a thread mid-blocking-I/O appears to leave the WebDriver's underlying HTTP client connection unusable for the `quit()` call that follows in the exception handler — the exception surfaces fine (the UI recovers), but the subsequent cleanup silently doesn't fully complete.

## Fix
Replaces thread interruption entirely with a cooperative cancellation check threaded through every Selenium wait in `BrowserLoginHandler`:
- New `until(WebDriverWait, Function<WebDriver, V>)` helper that checks a `BooleanSupplier` cancellation flag *before* evaluating the real wait condition, throwing `CancellationException` immediately if set — so a cancelled request fails within one poll interval, entirely on the same thread that's using the driver.
- All 16 `wait.until(...)` / `shortWait.until(...)` / `probeWait.until(...)` call sites in the class now route through it (the main 30s wait plus every short probe wait).
- `SamlAuthenticator.cancel()` no longer touches the `WebDriver` at all — it just flips a flag, passed into `BrowserLoginHandler` via `() -> cancelled`.
- `SwingMain` no longer calls `SwingWorker.cancel(true)` or tracks the worker for that purpose (removed the now-unneeded `activeCredentialWorker` field entirely).

Since the resulting exception now propagates through `performBrowserLogin`'s existing exception handling on the *same, uninterrupted* thread — architecturally indistinguishable from any other failure — cleanup should be exactly as reliable as the natural-failure path already was.

## Verification
Reused the same real-headless-Firefox harness from #79 (pointed at a login URL/title combination that genuinely blocks for the full 30s wait), rebuilt against this fix, and re-ran the identical scenario:
- Clicked the real "Cancel" button mid-wait — confirmed via the actual stack trace in the app's own logs that `CancellationException: Login cancelled` now fires directly from the new cooperative check (`BrowserLoginHandler.lambda$until$0`), not from an interrupt.
- Button/status recovered in ~7.4s (well within the 30s natural timeout, and via a real observed transition — not a polling-timeout artifact this time).
- No error dialog for the user-initiated cancel.
- **The browser process is now confirmed dead** via direct `ProcessHandle` inspection after cancelling — this was the core, previously-failing check in #79's verification, and it now passes. Re-verified the re-entrancy guard and the button-state-toggle behavior from #79 still work correctly too (regression check).
- Confirmed no orphaned test processes were left behind and the real desktop Firefox sharing this display was unaffected throughout.

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)