### PR TITLE
Silently check for updates on launch, surfaced via existing About dialog

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: ship-issue
+description: The standard workflow for shipping a bug fix or feature to aws-idp-saml-ui — file a GitHub issue, branch off main, implement, verify, bump the patch version, and open a PR. Use whenever picking up a bug fix or feature for this repo. Covers where Maven/tests run vs where the app runs, the per-issue patch-version-bump convention, and the PR checklist.
+---
+
+# Shipping a change to aws-idp-saml-ui
+
+The workflow this repo follows for every issue: file → branch → implement →
+verify → **bump the patch version** → PR. The version-bump step is the one easy
+to forget since nothing enforces it — it's a convention, not a build check.
+
+## 1. File the issue
+
+`gh issue create --title "..." --body "..."` — describe the bug/feature and,
+for a bug, the root cause if already known. This becomes the PR's `fixes #N`
+reference later.
+
+## 2. Branch off up-to-date main
+
+```bash
+git checkout main && git pull --ff-only
+git checkout -b fix/N-short-description   # or feature/N-short-description
+```
+
+This repo's existing branches follow `feature/<issue#>-<slug>` /
+`fix/<issue#>-<slug>` (see `git branch -a`) — include the issue number.
+
+If another PR merged since you last synced, `git pull --ff-only` catches
+that before you branch — don't skip it.
+
+## 3. Implement
+
+Normal edits. Check `git status` before anything destructive per the usual
+git safety rules.
+
+## 4. Test and build
+
+Maven only exists in a Docker container, not on the host — find it, don't
+assume a fixed name (it varies by session):
+
+```bash
+docker ps -a --format '{{.Names}} {{.Status}} {{.Image}}'   # find a maven-* container
+docker start <container-name>                                # if stopped
+docker exec <container-name> bash -lc "cd /projects/aws-idp-saml-ui && mvn -q test"
+docker exec <container-name> bash -lc "cd /projects/aws-idp-saml-ui && mvn -q package -DskipTests"
+```
+
+The container bind-mounts this host's `~/projects` directory to `/projects`.
+
+## 5. Verify Swing UI changes for real, not just via tests
+
+If the change touches a window/dialog/menu, don't stop at `mvn test` —
+launch the built jar and drive the real UI. See this repo's own `verify`
+skill for the specifics of this dev setup (build-in-container-run-on-host,
+why screenshots don't work here, isolating `-Duser.home` from the real
+`.aws` directory), and the more general `verify-java-swing` skill for the
+underlying techniques (modal-dialog `invokeAndWait` deadlock, synthetic
+`MouseEvent` dispatch, process safety on a shared display).
+
+## 6. Bump the patch version
+
+**Every issue-fixing PR bumps `pom.xml`'s `<version>` patch component by
+one** — `M.m.X` → `M.m.(X+1)`, e.g. `1.2.0` → `1.2.1`. This lands in the
+same PR as the fix/feature, not as a separate release PR.
+
+```xml
+<!-- pom.xml -->
+<version>1.2.1</version>
+```
+
+`pom.xml` is the only file to touch. The app's displayed version
+(`SwingMain.resolveCurrentVersion()`, shown in the About dialog) reads the
+JAR manifest's `Implementation-Version` at runtime, which Maven's jar
+plugin populates from `pom.xml` at build time — falling back to
+`src/main/resources/version.properties`, which is itself Maven-filtered
+from `${project.version}` (see the resource-filtering split in `pom.xml`'s
+`<build><resources>` section, which filters only that one file). There's no
+second place to edit, and no other file hardcodes the current version — a
+version string in `SwingMainVersionComparisonTest` is just an arbitrary
+fixture for `isNewerVersion()`/`extractJsonString()` comparison logic,
+unrelated to the real app version. Don't "fix" it to match.
+
+**Skip this step** for pure housekeeping that isn't shipping a user-facing
+change (e.g. branch cleanup, a memory/doc-only update, CI config tweaks
+with no issue behind them).
+
+**This is patch-only.** Bumping the minor or major version (`M.m` itself,
+or resetting the patch number back to 0 for a real numbered release) is a
+separate, deliberate decision the user makes when actually cutting a
+release — not something this per-issue convention decides on its own.
+
+## 7. Commit, push, open the PR
+
+Commit message references the issue (`fixes #N` or `(fixes #N)` in the
+subject). Push, then:
+
+```bash
+gh pr create --title "..." --body "$(cat <<'EOF'
+## Summary
+- Fixes #N: ...
+
+## Test plan
+- [x] ...
+EOF
+)"
+```
+
+## 8. Watch CI, then stop and wait
+
+```bash
+gh pr checks <N> --watch --interval 30
+```
+
+This is a real network call that can take a few minutes — run it via the
+Bash tool's `run_in_background`, don't poll it manually. Report the PR as
+ready once green. **Never merge without the user explicitly saying so for
+that specific PR** — reporting "ready to merge" is not the same as
+authorization to merge it.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/DatabaseManager.java
@@ -203,6 +203,16 @@ public class DatabaseManager {
         setConfig("start_minimized_to_tray", String.valueOf(enabled));
     }
 
+    // Intentionally not seeded: an absent value means no update has been auto-surfaced yet,
+    // so the silent startup check should show the first newer version it ever finds.
+    public String getLastNotifiedUpdateVersion() {
+        return getConfig("last_notified_update_version");
+    }
+
+    public void setLastNotifiedUpdateVersion(String version) {
+        setConfig("last_notified_update_version", version);
+    }
+
     // Token state methods
     public void updateExpiration(String profileName, Instant expiration) {
         if (profileName == null || expiration == null) {

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -83,6 +83,7 @@ public class SwingMain extends JFrame {
         loadProfiles();
         refreshStatusTable();
         startStatusPolling();
+        checkForUpdatesInBackground();
     }
 
     private void setLookAndFeel() {
@@ -301,6 +302,15 @@ public class SwingMain extends JFrame {
     }
 
     private void showAboutDialog() {
+        showAboutDialog(null);
+    }
+
+    /**
+     * @param knownNewerRelease if non-null (tagName-or-version, releaseUrl), an already-confirmed newer
+     *                          release to render immediately instead of performing a live GitHub check —
+     *                          used when the silent startup check already found and confirmed an update.
+     */
+    private void showAboutDialog(String[] knownNewerRelease) {
         final String currentVersion = resolveCurrentVersion();
 
         JPanel panel = new JPanel();
@@ -320,7 +330,7 @@ public class SwingMain extends JFrame {
         JLabel copyrightLabel = new JLabel("© OurGiant");
         copyrightLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-        JLabel updateLabel = new JLabel("Checking for updates...");
+        JLabel updateLabel = new JLabel(knownNewerRelease != null ? "" : "Checking for updates...");
         updateLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
         updateLabel.setForeground(Color.GRAY);
 
@@ -334,7 +344,70 @@ public class SwingMain extends JFrame {
         panel.add(Box.createVerticalStrut(8));
         panel.add(updateLabel);
 
-        SwingWorker<String[], Void> versionChecker = new SwingWorker<>() {
+        if (knownNewerRelease != null) {
+            applyUpdateAvailableLabel(updateLabel, knownNewerRelease[0], knownNewerRelease[1]);
+        } else {
+            SwingWorker<String[], Void> versionChecker = new SwingWorker<>() {
+                @Override
+                protected String[] doInBackground() {
+                    return fetchLatestRelease();
+                }
+
+                @Override
+                protected void done() {
+                    try {
+                        String[] release = get();
+                        if (release != null) {
+                            String latestTag = release[0];
+                            String releaseUrl = release[1];
+                            String latestVersion = latestTag.startsWith("v") ? latestTag.substring(1) : latestTag;
+                            if (isNewerVersion(latestVersion, currentVersion)) {
+                                applyUpdateAvailableLabel(updateLabel, latestVersion, releaseUrl);
+                            } else {
+                                updateLabel.setText("Up to date");
+                                updateLabel.setForeground(new Color(0, 128, 0));
+                            }
+                        } else {
+                            updateLabel.setText("Could not check for updates");
+                        }
+                    } catch (Exception e) {
+                        updateLabel.setText("Could not check for updates");
+                        logger.debug("Version check failed", e);
+                    }
+                    panel.revalidate();
+                    panel.repaint();
+                }
+            };
+            versionChecker.execute();
+        }
+
+        JOptionPane.showMessageDialog(this, panel, "About AWS IDP SAML UI", JOptionPane.PLAIN_MESSAGE);
+    }
+
+    private void applyUpdateAvailableLabel(JLabel updateLabel, String latestVersion, String releaseUrl) {
+        updateLabel.setText("<html><a href=''>Version " + latestVersion + " available — click to download</a></html>");
+        updateLabel.setForeground(new Color(0, 102, 204));
+        updateLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        updateLabel.addMouseListener(new java.awt.event.MouseAdapter() {
+            @Override
+            public void mouseClicked(java.awt.event.MouseEvent e) {
+                try {
+                    Desktop.getDesktop().browse(new java.net.URI(releaseUrl));
+                } catch (Exception ex) {
+                    logger.warn("Could not open release URL in browser", ex);
+                }
+            }
+        });
+    }
+
+    /**
+     * Silently checks for a newer release in the background. Does nothing if up to date or if the
+     * check fails (offline, rate-limited, etc.) — failures are only logged at debug level, matching
+     * fetchLatestRelease()'s own convention. If a newer version is found that hasn't already been
+     * auto-surfaced, opens the About dialog pre-populated with that result (no redundant re-fetch).
+     */
+    private void checkForUpdatesInBackground() {
+        SwingWorker<String[], Void> worker = new SwingWorker<>() {
             @Override
             protected String[] doInBackground() {
                 return fetchLatestRelease();
@@ -344,42 +417,27 @@ public class SwingMain extends JFrame {
             protected void done() {
                 try {
                     String[] release = get();
-                    if (release != null) {
-                        String latestTag = release[0];
-                        String releaseUrl = release[1];
-                        String latestVersion = latestTag.startsWith("v") ? latestTag.substring(1) : latestTag;
-                        if (isNewerVersion(latestVersion, currentVersion)) {
-                            updateLabel.setText("<html><a href=''>Version " + latestVersion + " available — click to download</a></html>");
-                            updateLabel.setForeground(new Color(0, 102, 204));
-                            updateLabel.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-                            updateLabel.addMouseListener(new java.awt.event.MouseAdapter() {
-                                @Override
-                                public void mouseClicked(java.awt.event.MouseEvent e) {
-                                    try {
-                                        Desktop.getDesktop().browse(new java.net.URI(releaseUrl));
-                                    } catch (Exception ex) {
-                                        logger.warn("Could not open release URL in browser", ex);
-                                    }
-                                }
-                            });
-                        } else {
-                            updateLabel.setText("Up to date");
-                            updateLabel.setForeground(new Color(0, 128, 0));
-                        }
-                    } else {
-                        updateLabel.setText("Could not check for updates");
+                    if (release == null) {
+                        return;
                     }
+                    String latestTag = release[0];
+                    String releaseUrl = release[1];
+                    String latestVersion = latestTag.startsWith("v") ? latestTag.substring(1) : latestTag;
+                    String currentVersion = resolveCurrentVersion();
+                    if (!isNewerVersion(latestVersion, currentVersion)) {
+                        return;
+                    }
+                    if (latestVersion.equals(databaseManager.getLastNotifiedUpdateVersion())) {
+                        return;
+                    }
+                    databaseManager.setLastNotifiedUpdateVersion(latestVersion);
+                    showAboutDialog(new String[]{latestVersion, releaseUrl});
                 } catch (Exception e) {
-                    updateLabel.setText("Could not check for updates");
-                    logger.debug("Version check failed", e);
+                    logger.debug("Silent update check failed", e);
                 }
-                panel.revalidate();
-                panel.repaint();
             }
         };
-        versionChecker.execute();
-
-        JOptionPane.showMessageDialog(this, panel, "About AWS IDP SAML UI", JOptionPane.PLAIN_MESSAGE);
+        worker.execute();
     }
 
     private String resolveCurrentVersion() {


### PR DESCRIPTION
## Summary
- Fixes #90: adds a silent, background update check on app launch that reuses the existing About dialog's GitHub release fetch/version-compare logic (`fetchLatestRelease()`, `isNewerVersion()`, `resolveCurrentVersion()`) instead of duplicating it.
- Runs off the EDT via `SwingWorker`. Does nothing on failure or when up to date — no dialog, no error, just a `logger.debug(...)` entry matching the existing convention for this codebase's expected-but-not-actionable failures.
- When a newer release is found, opens the existing About dialog pre-populated with that result (`showAboutDialog(String[] knownNewerRelease)`) rather than re-fetching and showing a redundant "Checking for updates..." state.
- Only auto-surfaces a given version once: the last auto-surfaced version is persisted via new `DatabaseManager.getLastNotifiedUpdateVersion()`/`setLastNotifiedUpdateVersion()` accessors, following the same unseeded-default pattern as `getLastUsedProfile()`. A manual File > About check is unaffected and always does a live check.
- Also fixes `.claude/skills/ship-issue/SKILL.md`, which had been added referencing an unrelated project (wrong repo name/paths/class names) and was misplaced outside `.claude/skills/` so it wasn't even loading as a skill. Rewritten to match this repo's actual conventions, and applied its patch-version-bump step (`pom.xml` 1.2.0 → 1.2.1) to this PR.

## Test plan
- [x] `mvn -q clean package` (existing unit tests, including `SwingMainVersionComparisonTest`) passes inside the Docker build container
- [x] Live harness against the built jar on a real X11 display: launching the real app (real GitHub API call, current release matches current version) confirms the silent check is a true no-op — no dialog opens, no version gets persisted
- [x] Same harness, invoking `showAboutDialog(String[])` directly with a simulated newer release: About dialog opens immediately in the "Version X available — click to download" state (correct text/color), with no live re-fetch
- [x] `DatabaseManager` persistence round-trip verified for the new preference key

🤖 Generated with [Claude Code](https://claude.com/claude-code)