### PR TITLE
Stop escaping colons when writing samlsts, breaking the Python CLI

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: verify
+description: How to build, launch, and drive this Java Swing app (aws-idp-saml-ui) to verify a change actually works, including this environment's specific gotchas (Docker-only Maven, no screenshot capture, modal-dialog deadlocks, shared real display).
+---
+
+# Verifying changes in aws-idp-saml-ui
+
+This is a Java Swing desktop app. Verifying a change means actually launching it
+and driving the real UI — not just `mvn test`. This doc captures the gotchas
+that cost real time to discover.
+
+## 1. Build (Maven only runs inside Docker)
+
+Maven isn't available on the host. Find/start the build container:
+
+```bash
+docker ps -a --format '{{.Names}} {{.Status}} {{.Image}}'   # find a maven-* container
+docker start <container-name>                                # if stopped
+docker exec <container-name> bash -lc "cd /projects/aws-idp-saml-ui && mvn -q clean package -DskipTests"
+```
+
+The container bind-mounts the host repo (commonly `/home/ryanleach/projects` →
+`/projects`), so edits made on the host are visible for the build.
+
+**Known quirk:** the bind mount can lag — the container sometimes serves a stale
+version of a just-edited file (confirmed on `pom.xml` and `.java` files),
+likely VirtioFS/gRPC-FUSE cache staleness. If a build doesn't reflect a recent
+edit, verify with `docker exec <container> grep <marker> <path>`; if stale,
+force a sync with `docker cp <host-file> <container>:<container-path>` before
+rebuilding.
+
+The built uber-jar lands at `target/aws-idp-saml-ui-all.jar`, visible on the
+host via the same mount.
+
+## 2. Launching against a real display
+
+`DISPLAY=:1` is a **real, shared X11 display** — the user's actual desktop
+session, not an isolated headless one. Treat it accordingly (see §5).
+
+**Always isolate from the user's real data** with `-Duser.home=<fake-home>`:
+
+```bash
+FAKEHOME=/path/to/scratch/fakehome
+mkdir -p "$FAKEHOME/.aws"
+cat > "$FAKEHOME/.aws/samlsts" <<'EOF'
+[global]
+idp_entry_url = https://example.okta.com/app/example/sso/saml
+username =
+
+[some-profile]
+aws_account_id = 111111111111
+role_arn = arn:aws:iam::111111111111:role/TestRole
+EOF
+
+DISPLAY=:1 java -Duser.home="$FAKEHOME" -jar target/aws-idp-saml-ui-all.jar
+```
+
+A `samlsts` file must exist or the app shows the first-run setup dialog instead
+of the main window. To test a profile with saved credentials but no `samlsts`
+entry (reproduces real bugs — see the context-menu fix in PR #86), also write
+`$FAKEHOME/.aws/credentials` directly with an INI section per profile
+(`aws_access_key_id`/`aws_secret_access_key`/`aws_session_token`).
+
+## 3. No screenshots are possible here
+
+`java.awt.Robot.createScreenCapture(...)` returns solid black for both a
+specific window and the full screen — confirmed empirically, not a bug in the
+capture code. This is the Wayland compositor blocking legacy X11 screen
+capture. **Don't spend time debugging this — it doesn't work in this
+environment.** Robot's mouse/keyboard input synthesis is a different subsystem
+and may work independently; test it, but don't assume — see §4 for a more
+reliable alternative.
+
+Verify visually-oriented changes via:
+- Live component introspection (reflection into field values, `.getText()` on
+  labels/buttons, table cell values) instead of pixels.
+- The app's own log output (SLF4J via logback, prints to stdout).
+- Extracting and viewing a generated image *asset* (e.g. an icon file) directly
+  with the Read tool — that's not a screen capture, it's just reading a file.
+
+## 4. Driving the UI programmatically
+
+Write a small standalone verification harness (a plain `.java` file in the
+scratchpad dir, compiled against the jar) rather than trying to interact
+manually:
+
+```bash
+javac -cp target/aws-idp-saml-ui-all.jar VerifyThing.java
+DISPLAY=:1 java -cp .:target/aws-idp-saml-ui-all.jar VerifyThing <fakehome> <args>
+```
+
+Inside the harness:
+- Set `System.setProperty("user.home", fakeHome)` **before** touching any app
+  class.
+- Construct the real app class on the EDT: `SwingUtilities.invokeAndWait(() -> { win[0] = new SwingMain(); win[0].setVisible(true); });`
+- Use reflection (`getDeclaredField(...).setAccessible(true)`) to reach private
+  fields on the live instance — components, managers, flags.
+- Click buttons with `button.doClick()`.
+- For rows/cells with no simple click method (e.g. right-clicking a `JTable`
+  row to trigger a context menu), dispatch a synthetic `MouseEvent` directly:
+  ```java
+  Rectangle r = table.getCellRect(row, col, true);   // LOCAL coords, not screen
+  MouseEvent press = new MouseEvent(table, MouseEvent.MOUSE_PRESSED,
+      System.currentTimeMillis(), 0, r.x + r.width/2, r.y + r.height/2,
+      1, /*popupTrigger=*/true, MouseEvent.BUTTON3);
+  table.dispatchEvent(press);
+  table.dispatchEvent(/* matching MOUSE_RELEASED */);
+  ```
+  `dispatchEvent` reaches real registered listeners reliably.
+  `java.awt.Robot`-based OS-level clicks were found **unreliable** for input
+  delivery in this environment (screenshots aside) — prefer `dispatchEvent`.
+
+### The modal-dialog deadlock (cost real time — avoid it)
+
+Never do this when the click opens a **modal** dialog
+(`JOptionPane.showConfirmDialog`, `showOptionDialog`, etc.):
+
+```java
+SwingUtilities.invokeAndWait(button::doClick);   // DEADLOCKS if this opens a modal dialog
+```
+
+The modal dialog pumps its own nested event loop that only returns once
+dismissed — nothing can dismiss it because the thread that would is the one
+blocked in `invokeAndWait`. Instead:
+
+```java
+SwingUtilities.invokeLater(button::doClick);
+Thread.sleep(400);                                // let it open
+JDialog dlg = findVisibleDialog();                // poll Window.getWindows()
+// ...read/interact with dlg...
+SwingUtilities.invokeAndWait(dlg::dispose);        // fine once it's a separate call
+```
+
+### Timing: don't trust a short polling window
+
+If you poll for a state change with a timeout and it doesn't arrive, that's
+evidence of "my poll window was too short," not "the operation completed
+around when I gave up." Prefer generous timeouts (tens of seconds, not
+hundreds of ms, for anything involving a real network/browser round trip) with
+periodic heartbeat logging, so a genuine hang is distinguishable from a slow
+success.
+
+## 5. Process safety — this is a shared, real desktop
+
+This session's display is the user's real one. Real apps (their actual
+browser, etc.) may already be running on it.
+
+- **Never** `pkill -f firefox` / `pkill -f chrome` / any broad process-name
+  match to clean up a stuck test — it can kill the user's real browser
+  session. This happened once; it didn't cause damage, but only by luck.
+- Track the exact PID of anything you launch (e.g. via
+  `ProcessHandle.allProcesses()` filtered to descendants of your own JVM's
+  PID, or a driver-reported PID like Selenium's `moz:processID` capability)
+  and kill **only that PID**.
+- For a stuck harness process itself (not a browser it launched), killing by
+  its own specific PID or a highly-specific class-name match
+  (`pkill -f VerifyThing`) is safe — it can't collide with anything else.
+
+## 6. Background runs
+
+Launching the app or a harness can take a while (browser startup, network).
+Use `run_in_background: true` and wait for the completion notification rather
+than polling with sleep loops. Wrap anything that could hang (e.g. due to the
+modal-dialog deadlock above) in a shell `timeout N` as a safety net so a bug
+in the harness can't hang the session indefinitely.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/ConfigManager.java
+++ b/src/main/java/com/ourgiant/saml/ConfigManager.java
@@ -1,5 +1,6 @@
 package com.ourgiant.saml;
 
+import org.ini4j.Config;
 import org.ini4j.Ini;
 import org.ini4j.Profile;
 import org.slf4j.Logger;
@@ -47,6 +48,7 @@ public class ConfigManager {
                     "\nPlease copy samlsts.demo to ~/.aws/samlsts and configure it.");
             }
             config = new Ini(configFile);
+            disableValueEscaping(config);
             logger.info("Configuration loaded from: {}", configFilePath);
         } catch (Exception e) {
             logger.error("Failed to load configuration", e);
@@ -313,6 +315,19 @@ public class ConfigManager {
         persistConfig();
     }
 
+    /**
+     * ini4j's default Config escapes ':' (and other delimiter-like characters) in values, turning
+     * URLs like "https://..." into "https\://..." on store(). The original Python CLI's ini parser
+     * doesn't understand that escaping, so it breaks compatibility (see #89). {@code Ini} instances
+     * share {@link Config#getGlobal()} by reference unless given their own, so this clones the config
+     * onto this instance rather than mutating the shared global one out from under every other Ini.
+     */
+    private static void disableValueEscaping(Ini ini) {
+        Config perInstanceConfig = ini.getConfig().clone();
+        perInstanceConfig.setEscape(false);
+        ini.setConfig(perInstanceConfig);
+    }
+
     private void persistConfig() throws Exception {
         File configFile = new File(configFilePath);
         config.store(configFile);
@@ -337,6 +352,7 @@ public class ConfigManager {
         configFile.getParentFile().mkdirs();
 
         Ini ini = new Ini();
+        disableValueEscaping(ini);
         for (Map.Entry<String, Map<String, String>> section : sections.entrySet()) {
             ini.add(section.getKey());
             for (Map.Entry<String, String> entry : section.getValue().entrySet()) {

--- a/src/test/java/com/ourgiant/saml/ConfigManagerTest.java
+++ b/src/test/java/com/ourgiant/saml/ConfigManagerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -21,6 +22,7 @@ class ConfigManagerTest {
     Path tempHome;
 
     private String originalUserHome;
+    private ConfigManager configManager;
 
     @BeforeEach
     void setUp() {
@@ -29,7 +31,15 @@ class ConfigManagerTest {
     }
 
     @AfterEach
-    void tearDown() {
+    void tearDown() throws Exception {
+        // ConfigManager's DatabaseManager keeps its SQLite connection open for the manager's
+        // lifetime; closing it here releases the file lock so @TempDir can delete it (Windows
+        // fails the whole test run otherwise - it errors on open file handles, unlike Linux/macOS).
+        if (configManager != null) {
+            Field field = ConfigManager.class.getDeclaredField("databaseManager");
+            field.setAccessible(true);
+            ((DatabaseManager) field.get(configManager)).close();
+        }
         System.setProperty("user.home", originalUserHome);
     }
 
@@ -53,7 +63,7 @@ class ConfigManagerTest {
                 loginpage = https://example.okta.com/app/foo/sso/saml
                 """);
 
-        ConfigManager configManager = new ConfigManager();
+        configManager = new ConfigManager();
         configManager.saveProfile("Fed-OKTA", Map.of("logintitle", "Fed OKTA Login"));
 
         String written = readSamlsts();
@@ -72,7 +82,7 @@ class ConfigManagerTest {
                 loginpage = https\\://example.okta.com/app/foo/sso/saml
                 """);
 
-        ConfigManager configManager = new ConfigManager();
+        configManager = new ConfigManager();
         assertEquals("https://example.okta.com/app/foo/sso/saml",
                 configManager.getProfile("Fed-OKTA").get("loginpage"));
 
@@ -84,7 +94,7 @@ class ConfigManagerTest {
 
     @Test
     void createConfig_doesNotEscapeColonsInUrls() throws Exception {
-        ConfigManager configManager = new ConfigManager(false);
+        configManager = new ConfigManager(false);
 
         Map<String, String> global = new LinkedHashMap<>();
         global.put("idp_entry_url", "https://example.okta.com/app/example/sso/saml");

--- a/src/test/java/com/ourgiant/saml/ConfigManagerTest.java
+++ b/src/test/java/com/ourgiant/saml/ConfigManagerTest.java
@@ -1,0 +1,100 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigManagerTest {
+
+    @TempDir
+    Path tempHome;
+
+    private String originalUserHome;
+
+    @BeforeEach
+    void setUp() {
+        originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", tempHome.toString());
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setProperty("user.home", originalUserHome);
+    }
+
+    private void writeSamlsts(String content) throws IOException {
+        Path awsDir = tempHome.resolve(".aws");
+        Files.createDirectories(awsDir);
+        Files.writeString(awsDir.resolve("samlsts"), content);
+    }
+
+    private String readSamlsts() throws IOException {
+        return Files.readString(tempHome.resolve(".aws").resolve("samlsts"));
+    }
+
+    @Test
+    void saveProfile_doesNotEscapeColonsInUrls() throws Exception {
+        writeSamlsts("""
+                [global]
+                idp_entry_url = https://example.okta.com/app/example/sso/saml
+
+                [Fed-OKTA]
+                loginpage = https://example.okta.com/app/foo/sso/saml
+                """);
+
+        ConfigManager configManager = new ConfigManager();
+        configManager.saveProfile("Fed-OKTA", Map.of("logintitle", "Fed OKTA Login"));
+
+        String written = readSamlsts();
+        assertFalse(written.contains("\\:"), "saved samlsts should not contain escaped colons:\n" + written);
+        assertTrue(written.contains("https://example.okta.com/app/foo/sso/saml"));
+    }
+
+    @Test
+    void saveProfile_selfHealsPreviouslyEscapedColons() throws Exception {
+        // Reproduces the bug in #89: a samlsts file already corrupted by the escaping bug.
+        writeSamlsts("""
+                [global]
+                idp_entry_url = https://example.okta.com/app/example/sso/saml
+
+                [Fed-OKTA]
+                loginpage = https\\://example.okta.com/app/foo/sso/saml
+                """);
+
+        ConfigManager configManager = new ConfigManager();
+        assertEquals("https://example.okta.com/app/foo/sso/saml",
+                configManager.getProfile("Fed-OKTA").get("loginpage"));
+
+        configManager.saveProfile("Fed-OKTA", Map.of("logintitle", "Fed OKTA Login"));
+
+        String written = readSamlsts();
+        assertFalse(written.contains("\\:"), "previously-escaped colon should be healed on next save:\n" + written);
+    }
+
+    @Test
+    void createConfig_doesNotEscapeColonsInUrls() throws Exception {
+        ConfigManager configManager = new ConfigManager(false);
+
+        Map<String, String> global = new LinkedHashMap<>();
+        global.put("idp_entry_url", "https://example.okta.com/app/example/sso/saml");
+        Map<String, Map<String, String>> sections = new LinkedHashMap<>();
+        sections.put("global", global);
+
+        configManager.createConfig(sections);
+
+        String written = readSamlsts();
+        assertFalse(written.contains("\\:"), "created samlsts should not contain escaped colons:\n" + written);
+        assertTrue(written.contains("https://example.okta.com/app/example/sso/saml"));
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #89: `ConfigManager`'s underlying ini4j library escapes `:` (and other delimiter-like characters) in values by default, so any `store()` turned URLs like `https://...` into `https\://...`. Since `persistConfig()`/`store()` rewrites the *entire* samlsts file, this corrupted URLs (e.g. a provider's `loginpage`) even when only an unrelated profile field was being saved through the profile management UI — exactly the symptom reported in #89. The original Python CLI's ini parser doesn't understand that escaping, so it broke compatibility with it.
- Root cause verified with a standalone ini4j repro before touching the app: default `Ini.store()` produces `loginpage = https\://...`; with escaping disabled it produces the correct `loginpage = https://...`.
- Fix: `ConfigManager.disableValueEscaping(Ini)` clones the config onto each `Ini` instance (used in both `loadConfig()` and `createConfig()`) rather than mutating `Config.getGlobal()` directly. `Ini` instances share the global `Config` singleton by reference unless given their own — mutating it directly leaked across test cases in the same JVM and would silently affect any other `Ini` use process-wide.
- Loading an already-corrupted samlsts file still parses correctly (the escape flag only affects future writes), so saving *any* profile after this fix self-heals previously-escaped values rather than requiring a manual repair.

## Test plan
- [x] New `ConfigManagerTest`: saving a profile doesn't escape colons in other values; a pre-corrupted fixture (`loginpage = https\://...`) parses correctly and self-heals on the next save; `createConfig()` (first-run setup) doesn't escape colons either
- [x] `mvn -q clean package` — full test suite passes inside the Docker build container
- [x] End-to-end verification against the real built jar on a real X11 display: launched the actual app, opened the real modal `ProfileEditDialog` for an existing profile, clicked its actual Save button after changing an unrelated field (IAM role), and confirmed on disk that the provider's `loginpage` URL is untouched with no escaped colons

🤖 Generated with [Claude Code](https://claude.com/claude-code)