### PR TITLE
Add macOS Dock-icon reopen fallback for the hidden-to-tray window

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -562,9 +563,32 @@ public class SwingMain extends JFrame {
                     setVisible(false);
                 }
             });
+
+            if (isMacOs()) {
+                registerMacDockReopenHandler();
+            }
         } catch (Exception e) {
             logger.warn("Failed to initialize system tray icon; window close will exit the app.", e);
             trayIcon = null;
+        }
+    }
+
+    private static boolean isMacOs() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("mac");
+    }
+
+    /**
+     * On macOS the tray icon alone isn't a reliable way back into a hidden window - it can go
+     * unnoticed in a crowded menu bar. The Dock icon is always present (this app doesn't set
+     * LSUIElement), so clicking it while the app is running with no visible windows is the more
+     * discoverable fallback. There's no isSupported() capability query for AppReopenedListener; it
+     * silently no-ops on platforms that don't fire the event, so this is only registered on macOS.
+     */
+    private void registerMacDockReopenHandler() {
+        try {
+            Desktop.getDesktop().addAppEventListener((java.awt.desktop.AppReopenedListener) e -> restoreFromTray());
+        } catch (Exception e) {
+            logger.warn("Failed to register macOS Dock reopen handler", e);
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes #93 (partially — the rest of that issue's items were reviewed and found not applicable, see below).
- A sister project (Kiro Control Panel) wrote up real macOS production lessons, one of which is an exact match here: a user closed the main window, didn't notice the tray icon in a crowded menu bar, and had no other way to get the window back. `SwingMain.initializeSystemTray()` (`SwingMain.java:535-569`) hides the window on close (`windowClosing` → `setVisible(false)`) with `restoreFromTray()` only reachable via that same tray icon.
- Fix: register a `java.awt.desktop.AppReopenedListener`, gated to macOS via `os.name` (there's no `isSupported()` capability query for this listener — it silently no-ops on platforms that don't fire the event), so clicking the always-present Dock icon also calls the existing `restoreFromTray()`.
- Reviewed the sister project's other lessons against this codebase and none of the rest apply:
  - **Apple Events / `NSAppleEventsUsageDescription`**: not applicable — this app never shells out via `osascript`/AppleScript.
  - **3-step jpackage `app-image` → patch `Info.plist` → `dmg` pipeline**: not applicable right now, since there's no Info.plist key this app currently needs to inject (that pipeline exists solely to support the Apple Events entitlement above).
  - **`WatchService` polling-latency timeouts**: not applicable — this app doesn't use `WatchService`.
  - **`FlowView`/`JEditorPane` flaky-test JDK bug**: not applicable — this app doesn't use `JEditorPane`.
  - **Test both Apple Silicon and Intel**: already done — `build.yml`'s `build-macos` job already matrices `macos-latest` (arm64) and `macos-15-intel` (x64).

## Test plan
- [x] `mvn -q clean package` — full test suite passes inside the Docker build container
- [x] Harness against the real built jar (Linux, no macOS available in this environment): confirms `isMacOs()` returns `false` here, `registerMacDockReopenHandler()` executes without throwing, and the existing tray hide/restore behavior (`windowClosing` → hide → `restoreFromTray()` → show) is unaffected
- [ ] **Needs manual verification on a real macOS machine**: close the main window while the tray icon is active, then click the Dock icon and confirm the window reappears. I don't have macOS available to verify this directly — flagging so this gets a real check before/after release rather than assuming the code is correct from Linux-only testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)