### PR TITLE
Harden SamlParser against XXE injection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SamlParser.java
+++ b/src/main/java/com/ourgiant/saml/SamlParser.java
@@ -34,6 +34,15 @@ public class SamlParser {
         // Parse XML
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
+        // samlResponse comes from the configured IdP's login response, not a trusted local file, so
+        // this must be hardened against XXE: a malicious/compromised IdP could otherwise smuggle a
+        // DOCTYPE with an external entity to read local files or trigger SSRF via an external DTD.
+        // Legitimate SAML responses never contain a DOCTYPE, so disallowing it entirely is safe.
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
         DocumentBuilder builder = factory.newDocumentBuilder();
         Document doc = builder.parse(new InputSource(new StringReader(decodedSaml)));
 

--- a/src/test/java/com/ourgiant/saml/SamlParserTest.java
+++ b/src/test/java/com/ourgiant/saml/SamlParserTest.java
@@ -2,8 +2,11 @@ package com.ourgiant.saml;
 
 import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,6 +59,33 @@ class SamlParserTest {
                 <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
                 </samlp:Response>
                 """;
+
+        assertThrows(Exception.class, () -> parser.parseRolesFromSaml(encode(saml)));
+    }
+
+    @Test
+    void parseRolesFromSaml_rejectsDoctypeDeclarations(@TempDir Path tempDir) throws Exception {
+        // Regression test for the XXE fix: a malicious/compromised IdP could otherwise smuggle a
+        // DOCTYPE with an external entity to read local files (or trigger SSRF via an external DTD).
+        // Legitimate SAML responses never contain a DOCTYPE, so parsing must reject it outright
+        // rather than silently resolving the entity.
+        Path secretFile = tempDir.resolve("secret.txt");
+        Files.writeString(secretFile, "top-secret-contents");
+
+        String saml = """
+                <?xml version="1.0"?>
+                <!DOCTYPE foo [<!ENTITY xxe SYSTEM "%s">]>
+                <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+                  <saml:Assertion>
+                    <saml:AttributeStatement>
+                      <saml:Attribute Name="https://aws.amazon.com/SAML/Attributes/Role">
+                        <saml:AttributeValue>&xxe;</saml:AttributeValue>
+                      </saml:Attribute>
+                    </saml:AttributeStatement>
+                  </saml:Assertion>
+                </samlp:Response>
+                """.formatted(secretFile.toUri());
 
         assertThrows(Exception.class, () -> parser.parseRolesFromSaml(encode(saml)));
     }


### PR DESCRIPTION
## Summary
- Fixes #95: `SamlParser.parseRolesFromSaml()` parsed the IdP's SAML response with a completely unhardened `DocumentBuilderFactory` — no `disallow-doctype-decl`, no external-entity disabling, no `FEATURE_SECURE_PROCESSING`. Found via a security review.
- The parsed XML isn't a trusted local file: `BrowserLoginHandler` scrapes the `SAMLResponse` value directly out of the page returned by the user-configured identity provider after login, and `SamlAuthenticator.java` passes it straight to this parser. A malicious or compromised IdP (or a MITM'd/misconfigured TLS session to it) could smuggle a `DOCTYPE` with an external entity to read local files (e.g. this app's own stored AWS credentials) or trigger SSRF/exfiltration via an external DTD — the entity/DTD reference lets the attacker control scheme, host, and port, not just a path.
- Fix disables DOCTYPE declarations and external entity resolution entirely on the factory before parsing. Legitimate SAML responses never contain a DOCTYPE, so this has no effect on normal operation.

## Test plan
- [x] New regression test (`SamlParserTest.parseRolesFromSaml_rejectsDoctypeDeclarations`): a SAML response containing a `DOCTYPE` with an external entity pointing at a local temp file is rejected outright (parse throws) rather than the entity being resolved
- [x] Existing `SamlParserTest` cases (extracting roles, ignoring non-role attributes, missing-assertion handling) still pass unchanged, confirming legitimate SAML parsing is unaffected
- [x] `mvn -q clean package` — full test suite passes inside the Docker build container

🤖 Generated with [Claude Code](https://claude.com/claude-code)