### PR TITLE
Fix XPath injection in AWS role selection (CWE-643)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.2.4</version>
+    <version>1.2.5</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
@@ -355,15 +355,44 @@ public class BrowserLoginHandler {
         return samlResponse;
     }
 
+    /**
+     * Builds a safe XPath string literal for an arbitrary value, avoiding XPath
+     * injection when the value contains quote characters. XPath has no escape
+     * character, so a value containing both quote types is split into
+     * concat() segments.
+     */
+    static String toXPathLiteral(String value) {
+        if (!value.contains("'")) {
+            return "'" + value + "'";
+        }
+        if (!value.contains("\"")) {
+            return "\"" + value + "\"";
+        }
+        String[] parts = value.split("'", -1);
+        StringBuilder sb = new StringBuilder("concat(");
+        for (int i = 0; i < parts.length; i++) {
+            if (i > 0) {
+                sb.append(", \"'\", ");
+            }
+            sb.append('\'').append(parts[i]).append('\'');
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
     private void selectRoleAndSignIn() {
         logger.info("Selecting role {}:{} on AWS SAML page", accountNumber, iamRole);
         statusCallback.accept("Selecting AWS role " + iamRole + " on AWS console...");
 
         driver.manage().window().maximize();
 
-        // Role element ID is the full ARN; match by account number and role name
+        // Role element ID is the full ARN; match by account number and role name.
+        // Values are escaped into XPath string literals since accountNumber/iamRole
+        // come from profile config and could otherwise break out of the quoted
+        // contains(...) argument and alter the query (CWE-643).
         String roleXpath = String.format(
-            "//*[contains(@id, '::%s:') and contains(@id, '%s')]", accountNumber, iamRole
+            "//*[contains(@id, %s) and contains(@id, %s)]",
+            toXPathLiteral("::" + accountNumber + ":"), toXPathLiteral(iamRole)
         );
 
         try {

--- a/src/test/java/com/ourgiant/saml/BrowserLoginHandlerXPathLiteralTest.java
+++ b/src/test/java/com/ourgiant/saml/BrowserLoginHandlerXPathLiteralTest.java
@@ -1,0 +1,57 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.Test;
+
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BrowserLoginHandlerXPathLiteralTest {
+
+    @Test
+    void toXPathLiteral_wrapsPlainValueInSingleQuotes() {
+        assertEquals("'my-role'", BrowserLoginHandler.toXPathLiteral("my-role"));
+    }
+
+    @Test
+    void toXPathLiteral_usesDoubleQuotesWhenValueContainsSingleQuote() {
+        assertEquals("\"O'Brien-role\"", BrowserLoginHandler.toXPathLiteral("O'Brien-role"));
+    }
+
+    @Test
+    void toXPathLiteral_usesConcatWhenValueContainsBothQuoteTypes() throws Exception {
+        String malicious = "x') or contains(@id,'\"and\"'";
+        String literal = BrowserLoginHandler.toXPathLiteral(malicious);
+        assertEquals(malicious, evaluateXPathLiteral(literal));
+    }
+
+    @Test
+    void toXPathLiteral_preventsInjectionBreakingOutOfContains() throws Exception {
+        // An attacker-controlled role name attempting to inject an "or true()" style
+        // predicate must be treated as a literal string, not as XPath syntax.
+        String injectionAttempt = "') or '1'='1";
+        String literal = BrowserLoginHandler.toXPathLiteral(injectionAttempt);
+        assertEquals(injectionAttempt, evaluateXPathLiteral(literal));
+    }
+
+    /**
+     * Evaluates the given XPath string-literal expression against a trivial document
+     * and returns the resulting string, proving it round-trips as data rather than
+     * being interpreted as XPath syntax.
+     */
+    private static String evaluateXPathLiteral(String literalExpression) throws Exception {
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element root = doc.createElement("root");
+        doc.appendChild(root);
+
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        return (String) xpath.evaluate("string(" + literalExpression + ")", doc, XPathConstants.STRING);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #98: `BrowserLoginHandler.selectRoleAndSignIn()` built its role-selection XPath with `String.format("//*[contains(@id, '::%s:') and contains(@id, '%s')]", accountNumber, iamRole)`, interpolating profile-sourced `accountNumber`/`iamRole` directly into the XPath string literals with no escaping. A value containing `'` could break out of the intended `contains(...)` argument and alter the query (CWE-643).
- Added `BrowserLoginHandler.toXPathLiteral(String)`, a standard safe XPath string-literal builder (single-quote wrap → double-quote wrap → `concat()` fallback when a value contains both quote types), and use it for both interpolated values.

## Test plan
- [x] `mvn test` — full suite passes, including new `BrowserLoginHandlerXPathLiteralTest` covering plain values, embedded single quotes, embedded both quote types, and an explicit injection-attempt payload (`') or '1'='1`) round-tripped through a real `javax.xml.xpath` evaluator to confirm it's treated as literal data, not XPath syntax.
- [x] `mvn package -DskipTests` — builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)