### PR TITLE
Bump version from 1.2.5 to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.2.5</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>


### PR DESCRIPTION
## Summary
Minor version bump to cut release 1.3.0. Since 1.2.0 this includes:
- macOS build/packaging support, `.icns` icon, Dock-icon reopen fallback for the hidden-to-tray window
- Cancellable in-progress credential requests, with orphaned browser process cleanup
- Silent background update checks surfaced in the About dialog
- Status-table context-menu fix (was acting on the wrong profile)
- `samlsts` colon-escaping fix for Python CLI compatibility
- Security hardening: XXE in `SamlParser`, XPath injection in AWS role selection, dependency vulnerability fixes

## Test plan
- [x] `mvn test` / `mvn package -DskipTests` pass (verified on the underlying PRs)
- [ ] Merge, then tag `v1.3.0` on the merge commit to trigger the release workflow