### PR TITLE
Prune profiles from the database once removed from samlsts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/ConfigManager.java
+++ b/src/main/java/com/ourgiant/saml/ConfigManager.java
@@ -308,11 +308,13 @@ public class ConfigManager {
     }
 
     /**
-     * Removes a profile section and persists to disk.
+     * Removes a profile section, persists to disk, and drops its token_state row so it
+     * doesn't linger in the database as an orphaned profile (see #101).
      */
     public void deleteProfile(String profileName) throws Exception {
         config.remove(profileName);
         persistConfig();
+        databaseManager.deleteProfileState(profileName);
     }
 
     /**

--- a/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
+++ b/src/main/java/com/ourgiant/saml/ConfigurationDialog.java
@@ -8,6 +8,7 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.util.HashSet;
 
 /**
  * Configuration dialog for setting application options.
@@ -29,6 +30,7 @@ public class ConfigurationDialog extends JDialog {
     private JCheckBox useFastPassCheckBox;
     private JCheckBox trayNotificationsCheckBox;
     private JCheckBox startMinimizedCheckBox;
+    private JButton forceRefreshButton;
     private JButton saveButton;
     private JButton cancelButton;
 
@@ -64,6 +66,7 @@ public class ConfigurationDialog extends JDialog {
         outerGbc.gridy = 4; outerPanel.add(buildAuthSection(), outerGbc);
         outerGbc.gridy = 5; outerPanel.add(buildNotificationsSection(), outerGbc);
         outerGbc.gridy = 6; outerPanel.add(buildStartupSection(), outerGbc);
+        outerGbc.gridy = 7; outerPanel.add(buildDataSection(), outerGbc);
 
         add(outerPanel, BorderLayout.CENTER);
 
@@ -214,6 +217,20 @@ public class ConfigurationDialog extends JDialog {
         return panel;
     }
 
+    private JPanel buildDataSection() {
+        JPanel panel = titledPanel("Data");
+        GridBagConstraints gbc = sectionGbc();
+
+        gbc.gridx = 1; gbc.gridy = 0; gbc.anchor = GridBagConstraints.EAST;
+        forceRefreshButton = new JButton("Force Refresh");
+        forceRefreshButton.setMnemonic(KeyEvent.VK_F);
+        forceRefreshButton.addActionListener(e -> forceRefreshProfiles());
+        forceRefreshButton.setToolTipText("Immediately purge stored status for profiles no longer present in the samlsts config");
+        panel.add(forceRefreshButton, gbc);
+
+        return panel;
+    }
+
     private static JPanel titledPanel(String title) {
         JPanel panel = new JPanel(new GridBagLayout());
         panel.setBorder(BorderFactory.createTitledBorder(title));
@@ -250,6 +267,28 @@ public class ConfigurationDialog extends JDialog {
             forgetPasswordButton.setEnabled(false);
             logger.info("Stored password cleared by user");
             JOptionPane.showMessageDialog(this, "Stored password cleared.", "Done", JOptionPane.INFORMATION_MESSAGE);
+        }
+    }
+
+    private void forceRefreshProfiles() {
+        int confirm = JOptionPane.showConfirmDialog(
+            this,
+            "Immediately remove stored status for any profile no longer present in the samlsts config?\n" +
+                "This normally happens automatically after a grace period; this forces it now.",
+            "Force Refresh",
+            JOptionPane.YES_NO_OPTION,
+            JOptionPane.WARNING_MESSAGE
+        );
+        if (confirm == JOptionPane.YES_OPTION) {
+            int pruned = databaseManager.reconcileProfiles(
+                new HashSet<>(configManager.getAvailableProfiles()), true);
+            logger.info("Force refresh pruned {} stale profile(s) from the database", pruned);
+            JOptionPane.showMessageDialog(this,
+                pruned == 0
+                    ? "No stale profiles found."
+                    : "Removed stored status for " + pruned + " stale profile(s).",
+                "Done",
+                JOptionPane.INFORMATION_MESSAGE);
         }
     }
 

--- a/src/main/java/com/ourgiant/saml/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/DatabaseManager.java
@@ -5,11 +5,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.sql.*;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Database manager for storing configuration and token state information.
@@ -17,6 +21,9 @@ import java.util.Map;
 public class DatabaseManager {
     private static final Logger logger = LoggerFactory.getLogger(DatabaseManager.class);
     private static final String DB_NAME = "aws_saml.db";
+    // Grace period a profile's token_state row survives after it disappears from samlsts
+    // before reconcileProfiles() prunes it, so a transient/hand-edit doesn't lose history.
+    private static final Duration STALE_PROFILE_TTL = Duration.ofDays(7);
     private Connection connection;
 
     public DatabaseManager() {
@@ -68,6 +75,27 @@ public class DatabaseManager {
 
             // Insert default configuration values
             insertDefaultConfig();
+        }
+
+        addColumnIfMissing("token_state", "missing_since", "TEXT");
+    }
+
+    /**
+     * Adds a column to an existing table if it isn't already there. SQLite has no
+     * "ADD COLUMN IF NOT EXISTS", and this schema predates any migration framework,
+     * so new columns are grafted on at startup this way.
+     */
+    private void addColumnIfMissing(String table, String column, String type) throws SQLException {
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery("PRAGMA table_info(" + table + ")")) {
+            while (rs.next()) {
+                if (column.equalsIgnoreCase(rs.getString("name"))) {
+                    return;
+                }
+            }
+        }
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("ALTER TABLE " + table + " ADD COLUMN " + column + " " + type);
         }
     }
 
@@ -280,6 +308,120 @@ public class DatabaseManager {
             logger.error("Failed to get all expirations", e);
         }
         return expirations;
+    }
+
+    /**
+     * Deletes the token_state row for a single profile immediately. Used when the user
+     * explicitly removes a profile via the UI, so its stale state doesn't linger for
+     * reconcileProfiles()'s grace period.
+     */
+    public void deleteProfileState(String profileName) {
+        if (profileName == null) {
+            return;
+        }
+        String sql = "DELETE FROM token_state WHERE profile_name = ?";
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            pstmt.setString(1, profileName);
+            pstmt.executeUpdate();
+            logger.debug("Deleted token state for profile {}", profileName);
+        } catch (SQLException e) {
+            logger.error("Failed to delete token state for profile: {}", profileName, e);
+        }
+    }
+
+    /**
+     * Reconciles token_state against the profiles currently defined in samlsts, using the
+     * standard grace period. See {@link #reconcileProfiles(Set, boolean)}.
+     *
+     * @return the number of stale profiles pruned
+     */
+    public int reconcileProfiles(Set<String> currentProfiles) {
+        return reconcileProfiles(currentProfiles, false);
+    }
+
+    /**
+     * A profile whose token_state row exists but is missing from {@code currentProfiles} is
+     * marked with a "missing since" timestamp the first time it's noticed, then pruned once
+     * it's been missing longer than {@link #STALE_PROFILE_TTL} — long enough to tolerate a
+     * transient hand-edit of the samlsts file without losing token history. A profile that
+     * reappears has its marker cleared.
+     *
+     * @param forceImmediate if true, prunes every profile missing from {@code currentProfiles}
+     *                        right now, bypassing the grace period (used by the "Force Refresh"
+     *                        button in the configuration dialog)
+     * @return the number of stale profiles pruned
+     */
+    public int reconcileProfiles(Set<String> currentProfiles, boolean forceImmediate) {
+        List<String[]> rows = new ArrayList<>(); // {profile_name, missing_since}
+        String selectSql = "SELECT profile_name, missing_since FROM token_state";
+        try (PreparedStatement pstmt = connection.prepareStatement(selectSql);
+             ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
+                rows.add(new String[]{rs.getString("profile_name"), rs.getString("missing_since")});
+            }
+        } catch (SQLException e) {
+            logger.error("Failed to read token_state for reconciliation", e);
+            return 0;
+        }
+
+        int pruned = 0;
+        Instant now = Instant.now();
+        for (String[] row : rows) {
+            String profileName = row[0];
+            String missingSince = row[1];
+
+            if (currentProfiles.contains(profileName)) {
+                if (missingSince != null) {
+                    clearMissingSince(profileName);
+                }
+                continue;
+            }
+
+            if (forceImmediate) {
+                deleteProfileState(profileName);
+                pruned++;
+            } else if (missingSince == null) {
+                markMissingSince(profileName, now);
+            } else if (isStale(missingSince, now)) {
+                deleteProfileState(profileName);
+                pruned++;
+            }
+        }
+
+        if (pruned > 0) {
+            logger.info("Pruned {} stale profile(s) from token_state", pruned);
+        }
+        return pruned;
+    }
+
+    private static boolean isStale(String missingSince, Instant now) {
+        try {
+            return Duration.between(Instant.parse(missingSince), now).compareTo(STALE_PROFILE_TTL) >= 0;
+        } catch (Exception e) {
+            // Unparseable marker shouldn't block pruning forever; treat it as stale.
+            return true;
+        }
+    }
+
+    private void markMissingSince(String profileName, Instant now) {
+        String sql = "UPDATE token_state SET missing_since = ? WHERE profile_name = ?";
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            pstmt.setString(1, now.toString());
+            pstmt.setString(2, profileName);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("Failed to mark profile as missing: {}", profileName, e);
+        }
+    }
+
+    private void clearMissingSince(String profileName) {
+        String sql = "UPDATE token_state SET missing_since = NULL WHERE profile_name = ?";
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            pstmt.setString(1, profileName);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("Failed to clear missing marker for profile: {}", profileName, e);
+        }
     }
 
     public void close() {

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -645,8 +646,11 @@ public class SwingMain extends JFrame {
     private void refreshStatusTable() {
         try {
             tokenStatusTableModel.setRowCount(0);
+            List<String> availableProfiles = configManager.getAvailableProfiles();
+            databaseManager.reconcileProfiles(new HashSet<>(availableProfiles));
+
             Set<String> profileSet = new TreeSet<>();
-            profileSet.addAll(configManager.getAvailableProfiles());
+            profileSet.addAll(availableProfiles);
             profileSet.addAll(tokenStateManager.getAllExpirations().keySet());
             profileSet.addAll(credentialManager.getAllProfileNames());
 

--- a/src/test/java/com/ourgiant/saml/DatabaseManagerTest.java
+++ b/src/test/java/com/ourgiant/saml/DatabaseManagerTest.java
@@ -1,0 +1,143 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DatabaseManagerTest {
+
+    @TempDir
+    Path tempHome;
+
+    private String originalUserHome;
+    private DatabaseManager databaseManager;
+
+    @BeforeEach
+    void setUp() {
+        originalUserHome = System.getProperty("user.home");
+        System.setProperty("user.home", tempHome.toString());
+        databaseManager = new DatabaseManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseManager.close();
+        System.setProperty("user.home", originalUserHome);
+    }
+
+    private void backdateMissingSince(String profileName, Instant when) throws Exception {
+        Field field = DatabaseManager.class.getDeclaredField("connection");
+        field.setAccessible(true);
+        Connection connection = (Connection) field.get(databaseManager);
+        try (PreparedStatement pstmt = connection.prepareStatement(
+                "UPDATE token_state SET missing_since = ? WHERE profile_name = ?")) {
+            pstmt.setString(1, when.toString());
+            pstmt.setString(2, profileName);
+            pstmt.executeUpdate();
+        }
+    }
+
+    private String readMissingSince(String profileName) throws Exception {
+        Field field = DatabaseManager.class.getDeclaredField("connection");
+        field.setAccessible(true);
+        Connection connection = (Connection) field.get(databaseManager);
+        try (PreparedStatement pstmt = connection.prepareStatement(
+                "SELECT missing_since FROM token_state WHERE profile_name = ?")) {
+            pstmt.setString(1, profileName);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                return rs.next() ? rs.getString("missing_since") : null;
+            }
+        }
+    }
+
+    @Test
+    void deleteProfileState_removesRow() {
+        databaseManager.updateExpiration("foo", Instant.now().plusSeconds(3600));
+        assertNotNull(databaseManager.getExpiration("foo"));
+
+        databaseManager.deleteProfileState("foo");
+
+        assertNull(databaseManager.getExpiration("foo"));
+    }
+
+    @Test
+    void reconcileProfiles_forceImmediate_prunesProfilesNotInCurrentSet() {
+        databaseManager.updateExpiration("keep", Instant.now().plusSeconds(3600));
+        databaseManager.updateExpiration("stale", Instant.now().plusSeconds(3600));
+
+        int pruned = databaseManager.reconcileProfiles(Set.of("keep"), true);
+
+        assertEquals(1, pruned);
+        assertNotNull(databaseManager.getExpiration("keep"));
+        assertNull(databaseManager.getExpiration("stale"));
+    }
+
+    @Test
+    void reconcileProfiles_withoutForce_doesNotPruneWithinGracePeriod() {
+        databaseManager.updateExpiration("stale", Instant.now().plusSeconds(3600));
+
+        int pruned = databaseManager.reconcileProfiles(Set.of(), false);
+
+        assertEquals(0, pruned, "a profile missing for the first time should be marked, not pruned");
+        assertNotNull(databaseManager.getExpiration("stale"));
+    }
+
+    @Test
+    void reconcileProfiles_withoutForce_prunesOnceGracePeriodElapses() throws Exception {
+        databaseManager.updateExpiration("stale", Instant.now().plusSeconds(3600));
+        databaseManager.reconcileProfiles(Set.of(), false); // marks missing_since = now
+
+        backdateMissingSince("stale", Instant.now().minus(java.time.Duration.ofDays(8)));
+
+        int pruned = databaseManager.reconcileProfiles(Set.of(), false);
+
+        assertEquals(1, pruned);
+        assertNull(databaseManager.getExpiration("stale"));
+    }
+
+    @Test
+    void reconcileProfiles_clearsMissingMarkerWhenProfileReappears() throws Exception {
+        databaseManager.updateExpiration("flaky", Instant.now().plusSeconds(3600));
+        databaseManager.reconcileProfiles(Set.of(), false); // marks missing
+        assertNotNull(readMissingSince("flaky"));
+
+        databaseManager.reconcileProfiles(Set.of("flaky"), false); // reappears
+
+        assertNull(readMissingSince("flaky"));
+        assertNotNull(databaseManager.getExpiration("flaky"));
+    }
+
+    @Test
+    void createTables_addsMissingSinceColumnToPreexistingTokenStateTable() throws Exception {
+        // Simulate an on-disk DB created before the missing_since column existed.
+        Field field = DatabaseManager.class.getDeclaredField("connection");
+        field.setAccessible(true);
+        Connection connection = (Connection) field.get(databaseManager);
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("ALTER TABLE token_state DROP COLUMN missing_since");
+        }
+
+        // Re-running the migration path should graft the column back on without error.
+        java.lang.reflect.Method method = DatabaseManager.class.getDeclaredMethod("createTables");
+        method.setAccessible(true);
+        method.invoke(databaseManager);
+
+        databaseManager.updateExpiration("foo", Instant.now().plusSeconds(3600));
+        databaseManager.reconcileProfiles(Set.of(), false);
+        assertNotNull(readMissingSince("foo"));
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #101: `token_state` rows in the SQLite database were insert-only — deleting or renaming a profile in `samlsts` (via the UI, or by hand-editing the file) left its row behind forever, so the status table kept showing profiles that no longer existed.
- `ConfigManager.deleteProfile()` now cascades an immediate `DatabaseManager.deleteProfileState()` call, so explicit deletes/renames via the UI clean up right away.
- Added `DatabaseManager.reconcileProfiles(currentProfiles, forceImmediate)`: a profile missing from `samlsts` gets a `missing_since` marker the first time it's noticed (new nullable column on `token_state`, added via a guarded `ALTER TABLE` since this schema has no migration framework) and is pruned once it's been missing for 7+ days — long enough to tolerate a transient hand-edit without losing token history. Reappearing clears the marker. This runs on every `refreshStatusTable()` call (startup, the 30s poll, the Refresh Status button, after profile add/edit/delete).
- Added a "Force Refresh" button to the Data section of the Configuration dialog that bypasses the grace period and prunes stale profiles immediately, reporting how many were removed.
- Bumped `pom.xml` patch version 1.3.0 → 1.3.1 per repo convention.

## Test plan
- [x] `mvn test` — full suite green, including 6 new `DatabaseManagerTest` cases covering `deleteProfileState`, forced/graced reconciliation, marker-clearing on reappearance, and the column-migration path against a pre-existing DB.
- [x] `mvn package -DskipTests` — builds clean.
- [x] Launched the real app against an isolated fake `~/.aws` (real X11 display, `-Duser.home` isolated) with a `samlsts` containing one profile and a seeded DB containing that profile plus a second, already-removed one. Confirmed via a driven-UI harness: startup reconciliation marks-but-doesn't-delete the stale profile (grace period), and clicking the real Force Refresh button in the real Configuration dialog immediately prunes it while leaving the live profile untouched — end to end, `RESULT: PASS`.