### PR TITLE
Add status filter checkboxes to the credential status table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -52,6 +52,10 @@ public class SwingMain extends JFrame {
     private DefaultTableModel tokenStatusTableModel;
     private JTable tokenStatusTable;
     private TableRowSorter<DefaultTableModel> tokenStatusRowSorter;
+    private JTextField profileFilterField;
+    private JCheckBox validStatusFilterCheckBox;
+    private JCheckBox expiredStatusFilterCheckBox;
+    private JCheckBox unknownStatusFilterCheckBox;
     private JLabel lastRefreshedLabel;
     private JLabel statusLabel;
     private JProgressBar loginProgressBar;
@@ -217,20 +221,30 @@ public class SwingMain extends JFrame {
         JPanel filterPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         JLabel filterLabel = new JLabel("Filter:");
         filterPanel.add(filterLabel);
-        JTextField profileFilterField = new JTextField(20);
+        profileFilterField = new JTextField(20);
         profileFilterField.setToolTipText("Narrow the table below to profiles whose name contains this text");
         filterLabel.setLabelFor(profileFilterField);
         filterPanel.add(profileFilterField);
         profileFilterField.getDocument().addDocumentListener(new DocumentListener() {
             @Override
-            public void insertUpdate(DocumentEvent e) { applyProfileFilter(profileFilterField.getText()); }
+            public void insertUpdate(DocumentEvent e) { applyFilters(); }
 
             @Override
-            public void removeUpdate(DocumentEvent e) { applyProfileFilter(profileFilterField.getText()); }
+            public void removeUpdate(DocumentEvent e) { applyFilters(); }
 
             @Override
-            public void changedUpdate(DocumentEvent e) { applyProfileFilter(profileFilterField.getText()); }
+            public void changedUpdate(DocumentEvent e) { applyFilters(); }
         });
+
+        filterPanel.add(new JLabel("Status:"));
+        validStatusFilterCheckBox = new JCheckBox("Valid", true);
+        expiredStatusFilterCheckBox = new JCheckBox("Expired", true);
+        unknownStatusFilterCheckBox = new JCheckBox("Unknown", true);
+        for (JCheckBox statusCheckBox : new JCheckBox[]{validStatusFilterCheckBox, expiredStatusFilterCheckBox, unknownStatusFilterCheckBox}) {
+            statusCheckBox.setToolTipText("Uncheck to hide profiles with this status from the table below");
+            statusCheckBox.addActionListener(e -> applyFilters());
+            filterPanel.add(statusCheckBox);
+        }
         tokenStatusPanel.add(filterPanel, BorderLayout.NORTH);
 
         JScrollPane tableScrollPane = new JScrollPane(tokenStatusTable);
@@ -706,12 +720,26 @@ public class SwingMain extends JFrame {
         }
     }
 
-    private void applyProfileFilter(String filterText) {
-        if (filterText == null || filterText.isBlank()) {
-            tokenStatusRowSorter.setRowFilter(null);
-        } else {
-            tokenStatusRowSorter.setRowFilter(RowFilter.regexFilter("(?i)" + Pattern.quote(filterText), 0));
+    private void applyFilters() {
+        List<RowFilter<Object, Object>> filters = new ArrayList<>();
+
+        String filterText = profileFilterField.getText();
+        if (filterText != null && !filterText.isBlank()) {
+            filters.add(RowFilter.regexFilter("(?i)" + Pattern.quote(filterText), 0));
         }
+
+        Set<String> allowedStatuses = new HashSet<>();
+        if (validStatusFilterCheckBox.isSelected()) allowedStatuses.add("VALID");
+        if (expiredStatusFilterCheckBox.isSelected()) allowedStatuses.add("EXPIRED");
+        if (unknownStatusFilterCheckBox.isSelected()) allowedStatuses.add("UNKNOWN");
+        filters.add(new RowFilter<>() {
+            @Override
+            public boolean include(Entry<?, ?> entry) {
+                return allowedStatuses.contains(entry.getStringValue(1));
+            }
+        });
+
+        tokenStatusRowSorter.setRowFilter(RowFilter.andFilter(filters));
     }
 
     private int getStatusOrder(String status) {


### PR DESCRIPTION
## Summary
- Fixes #102: adds Valid/Expired/Unknown checkboxes next to the existing profile-name filter in the Credential Status table, so the list can be narrowed to a subset of statuses (e.g. show Valid + Expired but hide Unknown) instead of scanning the whole table.
- All three are checked by default (no behavior change until a user deselects one).
- Combines with the existing name-substring filter via `RowFilter.andFilter`, so both apply together.
- Bumped `pom.xml` patch version 1.3.1 → 1.3.2 per repo convention.

## Test plan
- [x] `mvn test` — full suite green.
- [x] `mvn package -DskipTests` — builds clean.
- [x] Launched the real app against an isolated fake `~/.aws` (real X11 display) with three seeded profiles (one Valid, one Expired, one Unknown) and drove the real checkboxes/text field via a UI harness: default shows all 3; unchecking Unknown shows exactly Valid+Expired; isolating each status shows only that status; the name filter and status filters combine correctly (e.g. name filter "valid" + Valid unchecked → 0 rows). `RESULT: PASS`.