### PR TITLE
Slim ship-issue/verify skills to reference the generic Swing skills

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -1,118 +1,28 @@
 ---
 name: ship-issue
-description: The standard workflow for shipping a bug fix or feature to aws-idp-saml-ui — file a GitHub issue, branch off main, implement, verify, bump the patch version, and open a PR. Use whenever picking up a bug fix or feature for this repo. Covers where Maven/tests run vs where the app runs, the per-issue patch-version-bump convention, and the PR checklist.
+description: The standard workflow for shipping a bug fix or feature to aws-idp-saml-ui — file a GitHub issue, branch off main, implement, verify, bump the patch version, and open a PR. Use whenever picking up a bug fix or feature for this repo.
 ---
 
 # Shipping a change to aws-idp-saml-ui
 
-The workflow this repo follows for every issue: file → branch → implement →
-verify → **bump the patch version** → PR. The version-bump step is the one easy
-to forget since nothing enforces it — it's a convention, not a build check.
+This repo follows the generic `java-swing-ship-issue` workflow: file → branch
+→ implement → verify → **bump the patch version** → PR. See that skill for
+the full mechanics (Docker/Maven commands, why `pom.xml` is the only version
+file to touch, the PR/CI steps). This file covers only what's specific to
+this repo.
 
-## 1. File the issue
+## Project-specific facts
 
-`gh issue create --title "..." --body "..."` — describe the bug/feature and,
-for a bug, the root cause if already known. This becomes the PR's `fixes #N`
-reference later.
+- **Docker path**: `/projects/aws-idp-saml-ui` inside the Maven container
+  (see `java-swing-project-setup` §2 for finding/starting the container —
+  its name drifts across sessions).
+- **Branch naming**: `fix/<issue#>-<slug>` / `feature/<issue#>-<slug>` (see
+  `git branch -a` for existing examples) — always include the issue number.
+- **Verifying UI changes**: use this repo's own `verify` skill for the
+  specifics of this dev setup (jar path, `-Duser.home` isolation, `samlsts`
+  fixture format), plus `verify-java-swing` for the underlying techniques.
+  Per `java-swing-ship-issue` §5, don't stop at `mvn test` if the change
+  touches a window/dialog/menu, or bumps any `pom.xml` dependency version —
+  even one that looks UI-unrelated.
 
-## 2. Branch off up-to-date main
-
-```bash
-git checkout main && git pull --ff-only
-git checkout -b fix/N-short-description   # or feature/N-short-description
-```
-
-This repo's existing branches follow `feature/<issue#>-<slug>` /
-`fix/<issue#>-<slug>` (see `git branch -a`) — include the issue number.
-
-If another PR merged since you last synced, `git pull --ff-only` catches
-that before you branch — don't skip it.
-
-## 3. Implement
-
-Normal edits. Check `git status` before anything destructive per the usual
-git safety rules.
-
-## 4. Test and build
-
-Maven only exists in a Docker container, not on the host — find it, don't
-assume a fixed name (it varies by session):
-
-```bash
-docker ps -a --format '{{.Names}} {{.Status}} {{.Image}}'   # find a maven-* container
-docker start <container-name>                                # if stopped
-docker exec <container-name> bash -lc "cd /projects/aws-idp-saml-ui && mvn -q test"
-docker exec <container-name> bash -lc "cd /projects/aws-idp-saml-ui && mvn -q package -DskipTests"
-```
-
-The container bind-mounts this host's `~/projects` directory to `/projects`.
-
-## 5. Verify Swing UI changes for real, not just via tests
-
-If the change touches a window/dialog/menu, don't stop at `mvn test` —
-launch the built jar and drive the real UI. See this repo's own `verify`
-skill for the specifics of this dev setup (build-in-container-run-on-host,
-why screenshots don't work here, isolating `-Duser.home` from the real
-`.aws` directory), and the more general `verify-java-swing` skill for the
-underlying techniques (modal-dialog `invokeAndWait` deadlock, synthetic
-`MouseEvent` dispatch, process safety on a shared display).
-
-## 6. Bump the patch version
-
-**Every issue-fixing PR bumps `pom.xml`'s `<version>` patch component by
-one** — `M.m.X` → `M.m.(X+1)`, e.g. `1.2.0` → `1.2.1`. This lands in the
-same PR as the fix/feature, not as a separate release PR.
-
-```xml
-<!-- pom.xml -->
-<version>1.2.1</version>
-```
-
-`pom.xml` is the only file to touch. The app's displayed version
-(`SwingMain.resolveCurrentVersion()`, shown in the About dialog) reads the
-JAR manifest's `Implementation-Version` at runtime, which Maven's jar
-plugin populates from `pom.xml` at build time — falling back to
-`src/main/resources/version.properties`, which is itself Maven-filtered
-from `${project.version}` (see the resource-filtering split in `pom.xml`'s
-`<build><resources>` section, which filters only that one file). There's no
-second place to edit, and no other file hardcodes the current version — a
-version string in `SwingMainVersionComparisonTest` is just an arbitrary
-fixture for `isNewerVersion()`/`extractJsonString()` comparison logic,
-unrelated to the real app version. Don't "fix" it to match.
-
-**Skip this step** for pure housekeeping that isn't shipping a user-facing
-change (e.g. branch cleanup, a memory/doc-only update, CI config tweaks
-with no issue behind them).
-
-**This is patch-only.** Bumping the minor or major version (`M.m` itself,
-or resetting the patch number back to 0 for a real numbered release) is a
-separate, deliberate decision the user makes when actually cutting a
-release — not something this per-issue convention decides on its own.
-
-## 7. Commit, push, open the PR
-
-Commit message references the issue (`fixes #N` or `(fixes #N)` in the
-subject). Push, then:
-
-```bash
-gh pr create --title "..." --body "$(cat <<'EOF'
-## Summary
-- Fixes #N: ...
-
-## Test plan
-- [x] ...
-EOF
-)"
-```
-
-## 8. Watch CI, then stop and wait
-
-```bash
-gh pr checks <N> --watch --interval 30
-```
-
-This is a real network call that can take a few minutes — run it via the
-Bash tool's `run_in_background`, don't poll it manually. Report the PR as
-ready once green. **Never merge without the user explicitly saying so for
-that specific PR** — reporting "ready to merge" is not the same as
-authorization to merge it.
+No other repo-specific PR-checklist items beyond the generic workflow.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: verify
-description: How to build, launch, and drive this Java Swing app (aws-idp-saml-ui) to verify a change actually works, including this environment's specific gotchas (Docker-only Maven, no screenshot capture, modal-dialog deadlocks, shared real display).
+description: How to build, launch, and drive this Java Swing app (aws-idp-saml-ui) to verify a change actually works — this repo's Docker/build specifics, launch/config setup, and confirmed environment gotchas. See verify-java-swing for the general Swing-verification techniques this file doesn't repeat.
 ---
 
 # Verifying changes in aws-idp-saml-ui
 
-This is a Java Swing desktop app. Verifying a change means actually launching it
-and driving the real UI — not just `mvn test`. This doc captures the gotchas
-that cost real time to discover.
+This is a Java Swing desktop app. Verifying a change means actually launching
+it and driving the real UI — not just `mvn test`. This file covers what's
+specific to this repo's setup; see `verify-java-swing` for the general
+Swing-verification techniques (reflection/`dispatchEvent`, the modal-dialog
+`invokeAndWait` deadlock, timing, process safety on a shared display) used
+below.
 
 ## 1. Build (Maven only runs inside Docker)
 
@@ -35,7 +38,8 @@ host via the same mount.
 ## 2. Launching against a real display
 
 `DISPLAY=:1` is a **real, shared X11 display** — the user's actual desktop
-session, not an isolated headless one. Treat it accordingly (see §5).
+session, not an isolated headless one (see `verify-java-swing` §5 for the
+process-safety rules that follow from that).
 
 **Always isolate from the user's real data** with `-Duser.home=<fake-home>`:
 
@@ -64,25 +68,16 @@ entry (reproduces real bugs — see the context-menu fix in PR #86), also write
 ## 3. No screenshots are possible here
 
 `java.awt.Robot.createScreenCapture(...)` returns solid black for both a
-specific window and the full screen — confirmed empirically, not a bug in the
-capture code. This is the Wayland compositor blocking legacy X11 screen
-capture. **Don't spend time debugging this — it doesn't work in this
-environment.** Robot's mouse/keyboard input synthesis is a different subsystem
-and may work independently; test it, but don't assume — see §4 for a more
-reliable alternative.
-
-Verify visually-oriented changes via:
-- Live component introspection (reflection into field values, `.getText()` on
-  labels/buttons, table cell values) instead of pixels.
-- The app's own log output (SLF4J via logback, prints to stdout).
-- Extracting and viewing a generated image *asset* (e.g. an icon file) directly
-  with the Read tool — that's not a screen capture, it's just reading a file.
+specific window and the full screen — confirmed empirically in this
+environment, consistent with `verify-java-swing` §1's Wayland explanation.
+**Don't spend time debugging this — it doesn't work here.** Verify visually
+via live component introspection, log output, or reading a generated image
+*asset* directly — see `verify-java-swing` §1.
 
 ## 4. Driving the UI programmatically
 
 Write a small standalone verification harness (a plain `.java` file in the
-scratchpad dir, compiled against the jar) rather than trying to interact
-manually:
+scratchpad dir, compiled against the jar):
 
 ```bash
 javac -cp target/aws-idp-saml-ui-all.jar VerifyThing.java
@@ -92,74 +87,18 @@ DISPLAY=:1 java -cp .:target/aws-idp-saml-ui-all.jar VerifyThing <fakehome> <arg
 Inside the harness:
 - Set `System.setProperty("user.home", fakeHome)` **before** touching any app
   class.
-- Construct the real app class on the EDT: `SwingUtilities.invokeAndWait(() -> { win[0] = new SwingMain(); win[0].setVisible(true); });`
-- Use reflection (`getDeclaredField(...).setAccessible(true)`) to reach private
-  fields on the live instance — components, managers, flags.
-- Click buttons with `button.doClick()`.
-- For rows/cells with no simple click method (e.g. right-clicking a `JTable`
-  row to trigger a context menu), dispatch a synthetic `MouseEvent` directly:
-  ```java
-  Rectangle r = table.getCellRect(row, col, true);   // LOCAL coords, not screen
-  MouseEvent press = new MouseEvent(table, MouseEvent.MOUSE_PRESSED,
-      System.currentTimeMillis(), 0, r.x + r.width/2, r.y + r.height/2,
-      1, /*popupTrigger=*/true, MouseEvent.BUTTON3);
-  table.dispatchEvent(press);
-  table.dispatchEvent(/* matching MOUSE_RELEASED */);
-  ```
-  `dispatchEvent` reaches real registered listeners reliably.
-  `java.awt.Robot`-based OS-level clicks were found **unreliable** for input
-  delivery in this environment (screenshots aside) — prefer `dispatchEvent`.
+- Construct the real app class on the EDT:
+  `SwingUtilities.invokeAndWait(() -> { win[0] = new SwingMain(); win[0].setVisible(true); });`
 
-### The modal-dialog deadlock (cost real time — avoid it)
+See `verify-java-swing` §2–4 for the general techniques used from here:
+reflection into private fields, `button.doClick()`, synthetic `MouseEvent`
+dispatch for context menus, the modal-dialog `invokeAndWait` deadlock, and
+generous polling timeouts.
 
-Never do this when the click opens a **modal** dialog
-(`JOptionPane.showConfirmDialog`, `showOptionDialog`, etc.):
+## 5. Process safety and background runs
 
-```java
-SwingUtilities.invokeAndWait(button::doClick);   // DEADLOCKS if this opens a modal dialog
-```
-
-The modal dialog pumps its own nested event loop that only returns once
-dismissed — nothing can dismiss it because the thread that would is the one
-blocked in `invokeAndWait`. Instead:
-
-```java
-SwingUtilities.invokeLater(button::doClick);
-Thread.sleep(400);                                // let it open
-JDialog dlg = findVisibleDialog();                // poll Window.getWindows()
-// ...read/interact with dlg...
-SwingUtilities.invokeAndWait(dlg::dispose);        // fine once it's a separate call
-```
-
-### Timing: don't trust a short polling window
-
-If you poll for a state change with a timeout and it doesn't arrive, that's
-evidence of "my poll window was too short," not "the operation completed
-around when I gave up." Prefer generous timeouts (tens of seconds, not
-hundreds of ms, for anything involving a real network/browser round trip) with
-periodic heartbeat logging, so a genuine hang is distinguishable from a slow
-success.
-
-## 5. Process safety — this is a shared, real desktop
-
-This session's display is the user's real one. Real apps (their actual
-browser, etc.) may already be running on it.
-
-- **Never** `pkill -f firefox` / `pkill -f chrome` / any broad process-name
-  match to clean up a stuck test — it can kill the user's real browser
-  session. This happened once; it didn't cause damage, but only by luck.
-- Track the exact PID of anything you launch (e.g. via
-  `ProcessHandle.allProcesses()` filtered to descendants of your own JVM's
-  PID, or a driver-reported PID like Selenium's `moz:processID` capability)
-  and kill **only that PID**.
-- For a stuck harness process itself (not a browser it launched), killing by
-  its own specific PID or a highly-specific class-name match
-  (`pkill -f VerifyThing`) is safe — it can't collide with anything else.
-
-## 6. Background runs
-
-Launching the app or a harness can take a while (browser startup, network).
-Use `run_in_background: true` and wait for the completion notification rather
-than polling with sleep loops. Wrap anything that could hang (e.g. due to the
-modal-dialog deadlock above) in a shell `timeout N` as a safety net so a bug
-in the harness can't hang the session indefinitely.
+This session's display is the user's real, shared desktop — see
+`verify-java-swing` §5 for the process-cleanup rules (never a broad
+`pkill -f <browser>`; track exact PIDs). Launching the app or a harness can
+take a while; use `run_in_background: true` rather than polling, and wrap
+anything that could hang in a shell `timeout N` as a safety net.


### PR DESCRIPTION
## Summary
- Fixes #109: `.claude/skills/ship-issue/SKILL.md` and `.claude/skills/verify/SKILL.md` predated the `java-swing-ship-issue` and `verify-java-swing` global skills and duplicated most of their content verbatim (branch/build steps, version-bump mechanics, modal-dialog deadlock, `dispatchEvent` technique, process-safety rules).
- Both files are trimmed to only what's actually project-specific — Docker path, branch naming, jar path, `-Duser.home`/`samlsts` fixture setup, confirmed environment quirks (bind-mount staleness, Wayland screenshot black-screen) — and now reference the generic skills for the shared workflow/technique layers, mirroring the pattern `java-swing-project-setup` §6 describes.
- Concrete motivation: a since-dropped local WIP edit had manually re-added a paragraph to this repo's `ship-issue/SKILL.md` (widening the "verify UI" trigger to `pom.xml` dependency bumps) that already existed in `java-swing-ship-issue` §5 — the exact duplication-maintenance cost this issue flags.

## Test plan
- [x] Docs-only change (no `pom.xml`/code/test changes) — patch-version bump skipped per this repo's own `ship-issue` convention.
- [x] Diffed against `java-swing-ship-issue` and `verify-java-swing` to confirm every reference target/section number is accurate.
- [x] Confirmed no project-specific fact (container path, branch convention, jar name, `samlsts` fixture format, PR #86 reference, `SwingMain` class name) was dropped in the trim.