### PR TITLE
Add an amber 'expiring soon' status color to the credential table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -68,6 +68,7 @@ public class SwingMain extends JFrame {
 
     private TrayIcon trayIcon;
     private final Map<String, Instant> lastNotifiedExpiration = new HashMap<>();
+    private final Set<String> expiringSoonProfiles = new HashSet<>();
 
     private ConfigManager configManager;
     private CredentialManager credentialManager;
@@ -175,7 +176,7 @@ public class SwingMain extends JFrame {
         tokenStatusTable.setFillsViewportHeight(true);
         tokenStatusTable.setRowHeight(26);
         tokenStatusTable.setToolTipText("Click a row to select that profile above, or right-click for actions. Click a column header to sort.");
-        tokenStatusTable.getColumnModel().getColumn(1).setCellRenderer(new StatusTableCellRenderer());
+        tokenStatusTable.getColumnModel().getColumn(1).setCellRenderer(new StatusTableCellRenderer(expiringSoonProfiles));
         tokenStatusRowSorter = new TableRowSorter<>(tokenStatusTableModel);
         tokenStatusTable.setRowSorter(tokenStatusRowSorter);
         JPopupMenu tableContextMenu = createTableContextMenu();
@@ -660,6 +661,7 @@ public class SwingMain extends JFrame {
     private void refreshStatusTable() {
         try {
             tokenStatusTableModel.setRowCount(0);
+            expiringSoonProfiles.clear();
             List<String> availableProfiles = configManager.getAvailableProfiles();
             databaseManager.reconcileProfiles(new HashSet<>(availableProfiles));
 
@@ -686,6 +688,9 @@ public class SwingMain extends JFrame {
                     expiresAtText = formatInstant(expiration);
                     Duration remaining = Duration.between(now, expiration);
                     timeRemaining = formatDuration(remaining);
+                    if (remaining.compareTo(EXPIRY_WARNING_THRESHOLD) <= 0) {
+                        expiringSoonProfiles.add(profile);
+                    }
                     maybeNotifyExpiringSoon(profile, expiration, remaining);
                 } else {
                     status = "EXPIRED";
@@ -937,13 +942,25 @@ public class SwingMain extends JFrame {
     }
 
     private static class StatusTableCellRenderer extends DefaultTableCellRenderer {
+        private final Set<String> expiringSoonProfiles;
+
+        StatusTableCellRenderer(Set<String> expiringSoonProfiles) {
+            this.expiringSoonProfiles = expiringSoonProfiles;
+        }
+
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
                                                        boolean hasFocus, int row, int column) {
             Component component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
             if (column == 1 && value instanceof String status) {
                 switch (status) {
-                    case "VALID" -> component.setForeground(new Color(0, 128, 0));
+                    case "VALID" -> {
+                        // getValueAt (unlike the table model) takes view coordinates, so this
+                        // stays correct under the row sorter/filter.
+                        String profile = (String) table.getValueAt(row, 0);
+                        component.setForeground(expiringSoonProfiles.contains(profile)
+                            ? expiringSoonForeground() : new Color(0, 128, 0));
+                    }
                     case "EXPIRED" -> component.setForeground(expiredForeground());
                     default -> component.setForeground(unknownForeground());
                 }
@@ -963,6 +980,11 @@ public class SwingMain extends JFrame {
         // through to the light-background red — a sensible default there too.
         private static Color expiredForeground() {
             return FlatLaf.isLafDark() ? new Color(255, 110, 110) : Color.RED;
+        }
+
+        // Same light/dark contrast reasoning as expiredForeground().
+        private static Color expiringSoonForeground() {
+            return FlatLaf.isLafDark() ? new Color(255, 193, 7) : new Color(184, 92, 0);
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes #114: the credential status table's color renderer (`StatusTableCellRenderer`) only distinguished VALID (green) / EXPIRED (red) / UNKNOWN (gray). Meanwhile `maybeNotifyExpiringSoon` already fires a tray notification once a profile's remaining time drops below `EXPIRY_WARNING_THRESHOLD` (5 minutes) — the table itself didn't reflect that same urgency.
- Adds an amber color for VALID rows within that same threshold, computed once per `refreshStatusTable()` pass into a small `expiringSoonProfiles` set the renderer consults, so there's a single source of truth for "expiring soon" shared between the tray notification and the table color.
- Amber is theme-aware (dark vs. light FlatLaf variants), following the same pattern already used for `expiredForeground()`/`unknownForeground()`.

## Test plan
- [x] `mvn test` — full suite passes (exit 0).
- [x] Verified live in the running app (not just tests) via a reflection-based harness driving the real `SwingMain`/`JTable` — no screenshots possible in this environment (Wayland), so verification reads the actual rendered `Component.getForeground()` off `table.prepareRenderer(...)` for three seeded profiles (2h remaining, 2m remaining, already expired):
  - `expiring-soon` (VALID, 2m left) → `rgb(255,193,7)` (dark theme amber)
  - `valid-far` (VALID, 2h left) → `rgb(0,128,0)` (unchanged green)
  - `expired` → `rgb(255,110,110)` (unchanged, theme-aware red)
  - Re-ran with the theme forced to Flat Light: `expiring-soon` → `rgb(184,92,0)`, confirming both light/dark branches render correctly.
- [x] Patch version bumped 1.3.2 → 1.3.3 per this repo's `ship-issue` convention.