### PR TITLE
Fix racy 0-minute password expiration check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/PasswordManager.java
+++ b/src/main/java/com/ourgiant/saml/PasswordManager.java
@@ -142,7 +142,7 @@ public class PasswordManager {
             long expirationMillis = expirationMinutes * 60L * 1000L;
             long ageMillis = System.currentTimeMillis() - storedAt.toEpochMilli();
 
-            if (ageMillis > expirationMillis) {
+            if (ageMillis >= expirationMillis) {
                 logger.info("Stored password has expired (age: {} minutes, expiration: {} minutes)",
                     ageMillis / 60000, expirationMinutes);
                 clearPassword();


### PR DESCRIPTION
## Summary
- Fixes #118: `PasswordManager.retrievePassword()` only expired a stored password when `ageMillis > expirationMillis` (strict greater-than). With a 0-minute expiration, that's only true if retrieval happens in a later millisecond than storage — reliably true on Linux/Windows CI timing, reliably false on macOS CI, where `PasswordManagerTest.retrievePassword_returnsNullAndClearsWhenExpired` failed consistently (reproduced across a re-run) on both macOS runners while passing on Linux/Windows.
- Changes the comparison to `ageMillis >= expirationMillis`, so a 0-minute expiration means "expires immediately" rather than "expires if we're unlucky with clock timing." No behavior change for realistic non-zero expiration windows.
- Local expiration-check logic only — not the AES-GCM encrypt/decrypt wire format — so no cross-repo (Python app / python-aws-deployer) coordination needed.
- Discovered as an unrelated CI failure while verifying PR #117; filed and fixed separately rather than bundled in there.

## Test plan
- [x] `mvn test -Dtest=PasswordManagerTest` — the previously-flaky test's log now shows `Stored password has expired (age: 0 minutes, expiration: 0 minutes)` immediately, confirming the fix.
- [x] `mvn test` — full suite passes (exit 0).
- [x] Patch version bumped 1.3.2 → 1.3.3 per this repo's `ship-issue` convention.