### PR TITLE
Batch-refresh expiring/expired profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -48,6 +48,7 @@ public class SwingMain extends JFrame {
     private JButton showEncryptedButton;
     private JButton showCredentialsButton;
     private JButton openConsoleButton;
+    private JButton batchRefreshButton;
 
     private DefaultTableModel tokenStatusTableModel;
     private JTable tokenStatusTable;
@@ -257,6 +258,13 @@ public class SwingMain extends JFrame {
         refreshStatusButton.addActionListener(e -> refreshStatusTable());
         refreshStatusButton.setToolTipText("Recheck credential expiration status for all profiles");
         statusControls.add(refreshStatusButton);
+
+        batchRefreshButton = new JButton("Refresh Expiring/Expired");
+        batchRefreshButton.setMnemonic(KeyEvent.VK_E);
+        batchRefreshButton.addActionListener(new BatchRefreshListener());
+        batchRefreshButton.setToolTipText("Renew credentials (via browser login) for every profile that's "
+            + "expired or within " + formatDuration(EXPIRY_WARNING_THRESHOLD) + " of expiring");
+        statusControls.add(batchRefreshButton);
         lastRefreshedLabel = new JLabel();
         statusControls.add(lastRefreshedLabel);
         tokenStatusPanel.add(statusControls, BorderLayout.SOUTH);
@@ -856,6 +864,7 @@ public class SwingMain extends JFrame {
         // Swap the button to a Cancel affordance during processing
         requestCredentialsButton.setText("Cancel");
         requestCredentialsButton.setToolTipText("Cancel the in-progress credential request");
+        batchRefreshButton.setEnabled(false);
         credentialRequestInProgress = true;
         credentialRequestCancelledByUser = false;
         loginProgressBar.setVisible(true);
@@ -881,6 +890,7 @@ public class SwingMain extends JFrame {
             protected void done() {
                 requestCredentialsButton.setText("Request Credentials");
                 requestCredentialsButton.setToolTipText("Launch browser login and fetch AWS credentials for the selected profile");
+                batchRefreshButton.setEnabled(true);
                 credentialRequestInProgress = false;
                 loginProgressBar.setVisible(false);
                 activeAuthenticator = null;
@@ -915,6 +925,165 @@ public class SwingMain extends JFrame {
         if (activeAuthenticator != null) {
             activeAuthenticator.cancel();
         }
+    }
+
+    private class BatchRefreshListener implements ActionListener {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (credentialRequestInProgress) {
+                cancelCredentialRequest();
+            } else {
+                refreshExpiringOrExpiredProfiles();
+            }
+        }
+    }
+
+    private record BatchRefreshResult(String profile, boolean success, String detail) {
+    }
+
+    /**
+     * Sequentially drives a fresh credential request for every profile currently EXPIRED or
+     * within EXPIRY_WARNING_THRESHOLD of expiring, so a user managing many profiles doesn't have
+     * to repeat "select profile, click Request Credentials, wait" once per stale profile. Shares
+     * credentialRequestInProgress/activeAuthenticator/credentialRequestCancelledByUser with the
+     * single-profile flow (requestCredentialsForProfile/cancelCredentialRequest) so the two can't
+     * run concurrently and Cancel works the same way for both.
+     */
+    private void refreshExpiringOrExpiredProfiles() {
+        if (credentialRequestInProgress) {
+            JOptionPane.showMessageDialog(SwingMain.this,
+                "A credential request is already in progress. Cancel it first or wait for it to finish.",
+                "Request In Progress",
+                JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        List<String> targets = new ArrayList<>();
+        for (int row = 0; row < tokenStatusTableModel.getRowCount(); row++) {
+            String profile = (String) tokenStatusTableModel.getValueAt(row, 0);
+            String status = (String) tokenStatusTableModel.getValueAt(row, 1);
+            if ("EXPIRED".equals(status) || expiringSoonProfiles.contains(profile)) {
+                targets.add(profile);
+            }
+        }
+
+        if (targets.isEmpty()) {
+            JOptionPane.showMessageDialog(SwingMain.this,
+                "No profiles are currently expired or expiring soon.",
+                "Nothing To Refresh",
+                JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
+
+        batchRefreshButton.setText("Cancel");
+        batchRefreshButton.setToolTipText("Cancel the in-progress batch refresh");
+        requestCredentialsButton.setEnabled(false);
+        credentialRequestInProgress = true;
+        credentialRequestCancelledByUser = false;
+        loginProgressBar.setVisible(true);
+        statusLabel.setText("Starting batch refresh for " + targets.size() + " profile(s)...");
+
+        SwingWorker<List<BatchRefreshResult>, String> worker = new SwingWorker<>() {
+            @Override
+            protected List<BatchRefreshResult> doInBackground() {
+                List<BatchRefreshResult> results = new ArrayList<>();
+                for (int i = 0; i < targets.size(); i++) {
+                    if (credentialRequestCancelledByUser) {
+                        break;
+                    }
+                    String profile = targets.get(i);
+                    String progressPrefix = "Refreshing " + (i + 1) + " of " + targets.size() + " (" + profile + "): ";
+                    publish(progressPrefix + "starting...");
+
+                    SamlAuthenticator authenticator = new SamlAuthenticator();
+                    activeAuthenticator = authenticator;
+                    try {
+                        authenticator.requestCredentials(
+                            profile,
+                            databaseManager.getFastPassEnabled(),
+                            showBrowserCheckBox.isSelected(),
+                            msg -> publish(progressPrefix + msg)
+                        );
+                        results.add(new BatchRefreshResult(profile, true, null));
+                    } catch (Exception ex) {
+                        if (credentialRequestCancelledByUser) {
+                            // Cancelled mid-flight: don't report the interrupted profile as a failure.
+                            break;
+                        }
+                        CredentialRequestError error = CredentialRequestError.classify(ex);
+                        results.add(new BatchRefreshResult(profile, false, error.statusMessage()));
+                    } finally {
+                        activeAuthenticator = null;
+                    }
+                }
+                return results;
+            }
+
+            @Override
+            protected void process(List<String> chunks) {
+                if (!chunks.isEmpty()) {
+                    statusLabel.setText(chunks.get(chunks.size() - 1));
+                }
+            }
+
+            @Override
+            protected void done() {
+                batchRefreshButton.setText("Refresh Expiring/Expired");
+                batchRefreshButton.setToolTipText("Renew credentials (via browser login) for every profile that's "
+                    + "expired or within " + formatDuration(EXPIRY_WARNING_THRESHOLD) + " of expiring");
+                requestCredentialsButton.setEnabled(true);
+                credentialRequestInProgress = false;
+                loginProgressBar.setVisible(false);
+                activeAuthenticator = null;
+
+                List<BatchRefreshResult> results;
+                try {
+                    results = get();
+                } catch (Exception ex) {
+                    statusLabel.setText("Batch refresh failed: " + ex.getMessage());
+                    return;
+                }
+
+                refreshStatusTable();
+                updateCredentialButtons();
+
+                long succeeded = results.stream().filter(BatchRefreshResult::success).count();
+                List<BatchRefreshResult> failures = results.stream().filter(r -> !r.success()).toList();
+                boolean cancelled = credentialRequestCancelledByUser;
+                int notAttempted = targets.size() - results.size();
+
+                if (cancelled) {
+                    statusLabel.setText(String.format(
+                        "Batch refresh cancelled: %d succeeded, %d failed, %d not attempted.",
+                        succeeded, failures.size(), notAttempted));
+                } else {
+                    statusLabel.setText(String.format(
+                        "Batch refresh complete: %d succeeded, %d failed.", succeeded, failures.size()));
+                }
+
+                if (failures.isEmpty() && !cancelled) {
+                    JOptionPane.showMessageDialog(SwingMain.this,
+                        "Refreshed " + succeeded + " profile(s) successfully.",
+                        "Batch Refresh Complete",
+                        JOptionPane.INFORMATION_MESSAGE);
+                } else {
+                    StringBuilder detail = new StringBuilder();
+                    detail.append(succeeded).append(" succeeded, ").append(failures.size()).append(" failed");
+                    if (cancelled) {
+                        detail.append(", ").append(notAttempted).append(" not attempted (cancelled)");
+                    }
+                    detail.append(".\n");
+                    for (BatchRefreshResult r : failures) {
+                        detail.append("\n- ").append(r.profile()).append(": ").append(r.detail());
+                    }
+                    JOptionPane.showMessageDialog(SwingMain.this,
+                        detail.toString(),
+                        cancelled ? "Batch Refresh Cancelled" : "Batch Refresh Complete With Errors",
+                        JOptionPane.WARNING_MESSAGE);
+                }
+            }
+        };
+        worker.execute();
     }
 
     private void showCredentialErrorDialog(String selectedProfile, CredentialRequestError error) {


### PR DESCRIPTION
## Summary
- Fixes #113: `requestCredentialsForProfile` drove one browser SAML login per invocation, one profile at a time via the combo box. For someone federating into many AWS accounts, refreshing at the start of a session meant repeating that click-and-wait once per stale profile — the whole reason this app supports "any number of AWS profiles" but the UI didn't scale with the profile count.
- Adds a "Refresh Expiring/Expired" button (next to "Refresh Status") that walks every profile currently EXPIRED or inside the existing `EXPIRY_WARNING_THRESHOLD` (the same threshold #114 already uses for the amber status color and the tray notification), driving a `SamlAuthenticator.requestCredentials(...)` call for each, sequentially, in a single `SwingWorker`.
- Shares `credentialRequestInProgress` / `activeAuthenticator` / `credentialRequestCancelledByUser` with the existing single-profile flow, so:
  - The two flows can't run concurrently (each disables the other's button while running).
  - Clicking "Cancel" (the batch button's in-progress state) reuses the exact same `cancelCredentialRequest()` the single-profile flow already uses.
- Reports one summary at the end (succeeded/failed/not-attempted counts, plus each failure's reason) instead of a popup per profile.

## Test plan
- [x] `mvn test` — full suite passes.
- [x] Verified live in the running app via a reflection-driven harness (no real IdP available in this environment, so profiles point at an unreachable local endpoint to exercise the real failure/cancellation paths — not mocked):
  - **No eligible profiles**: button never enters the in-progress state; "Nothing To Refresh" info dialog shown immediately.
  - **Cancel mid-flight**: clicking Cancel while profile 1/2 is mid-login correctly propagates `CancellationException`, stops before starting the next profile, reports "0 succeeded, 0 failed, 2 not attempted (cancelled)", and resets both buttons.
  - **Full run**: both seeded profiles (EXPIRED + expiring-soon) are attempted sequentially ("Refreshing 1 of 2" → "2 of 2"), both fail against the unreachable endpoint, and the final dialog lists "0 succeeded, 2 failed" with each profile's specific failure reason — confirming per-profile error classification and summary formatting.
- [x] Patch version bumped 1.3.3 → 1.3.4 per this repo's `ship-issue` convention.