### PR TITLE
Unify profile selection with the filterable status table

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.4</version>
+    <version>1.3.5</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -180,17 +180,21 @@ public class SwingMain extends JFrame {
         tokenStatusTable.getColumnModel().getColumn(1).setCellRenderer(new StatusTableCellRenderer(expiringSoonProfiles));
         tokenStatusRowSorter = new TableRowSorter<>(tokenStatusTableModel);
         tokenStatusTable.setRowSorter(tokenStatusRowSorter);
+        // Single source of truth for "which profile is selected to act on": any change to the
+        // table's selected row (mouse click, keyboard arrow navigation, or the context menu's
+        // own setRowSelectionInterval below) syncs the combo box, instead of each interaction
+        // path needing its own manual profileComboBox.setSelectedItem(...) call.
+        tokenStatusTable.getSelectionModel().addListSelectionListener(e -> {
+            if (e.getValueIsAdjusting()) {
+                return;
+            }
+            int row = tokenStatusTable.getSelectedRow();
+            if (row >= 0) {
+                profileComboBox.setSelectedItem(tokenStatusTable.getValueAt(row, 0));
+            }
+        });
         JPopupMenu tableContextMenu = createTableContextMenu();
         tokenStatusTable.addMouseListener(new java.awt.event.MouseAdapter() {
-            @Override
-            public void mouseClicked(java.awt.event.MouseEvent e) {
-                int row = tokenStatusTable.rowAtPoint(e.getPoint());
-                if (row >= 0) {
-                    String profile = (String) tokenStatusTableModel.getValueAt(tokenStatusTable.convertRowIndexToModel(row), 0);
-                    profileComboBox.setSelectedItem(profile);
-                }
-            }
-
             @Override
             public void mousePressed(java.awt.event.MouseEvent e) {
                 maybeShowContextMenu(e);
@@ -215,7 +219,6 @@ public class SwingMain extends JFrame {
                 // state (not defined in samlsts) — setSelectedItem silently no-ops for those. Track
                 // the right-clicked profile directly so menu actions always target the right row.
                 contextMenuTargetProfile = profile;
-                profileComboBox.setSelectedItem(profile);
                 tableContextMenu.show(tokenStatusTable, e.getX(), e.getY());
             }
         });


### PR DESCRIPTION
## Summary
- Fixes #115. Original ask assumed the status table and the "Select Profile" combo box were fully disconnected — investigation found mouse clicks already synced them (`mouseClicked` called `profileComboBox.setSelectedItem(...)`), and the context menu had its own duplicate copy of the same call. The actual gap: **keyboard arrow-key navigation of the table never synced the combo box at all**, since the sync logic only lived in a `mouseClicked` handler.
- Replaces both manual call sites with a single `ListSelectionListener` on the table's selection model, which fires for every way the selected row can change — mouse click, keyboard navigation, and the context menu's `setRowSelectionInterval` — consolidating "which profile do actions target" into one code path instead of two, and closing the keyboard-nav gap as a side effect of that consolidation.
- No behavior change for existing mouse-driven interactions; net removal of duplicated logic (14 insertions, 11 deletions across a small, contained diff).

## Test plan
- [x] `mvn test` — full suite passes.
- [x] Verified live via a reflection-driven harness: programmatically moving the table's selection model through 3 profiles (the same underlying call keyboard arrow navigation makes) confirmed the combo box now tracks every row, which it previously didn't — `row=0..2` all showed `match=true` between the table's profile column and the combo box's selected item.
- [x] Patch version bumped 1.3.4 → 1.3.5 per this repo's `ship-issue` convention.