### PR TITLE
Pin/reorder frequently used profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.5</version>
+    <version>1.3.6</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/DatabaseManager.java
@@ -69,9 +69,19 @@ public class DatabaseManager {
             )
             """;
 
+        // Pinned-profile order table. A row's presence means the profile is pinned;
+        // pin_order is its position (0 = top) among pinned profiles.
+        String createPinsTable = """
+            CREATE TABLE IF NOT EXISTS profile_pins (
+                profile_name TEXT PRIMARY KEY,
+                pin_order INTEGER NOT NULL
+            )
+            """;
+
         try (Statement stmt = connection.createStatement()) {
             stmt.execute(createConfigTable);
             stmt.execute(createTokenTable);
+            stmt.execute(createPinsTable);
 
             // Insert default configuration values
             insertDefaultConfig();
@@ -379,11 +389,13 @@ public class DatabaseManager {
 
             if (forceImmediate) {
                 deleteProfileState(profileName);
+                deleteProfilePin(profileName);
                 pruned++;
             } else if (missingSince == null) {
                 markMissingSince(profileName, now);
             } else if (isStale(missingSince, now)) {
                 deleteProfileState(profileName);
+                deleteProfilePin(profileName);
                 pruned++;
             }
         }
@@ -421,6 +433,102 @@ public class DatabaseManager {
             pstmt.executeUpdate();
         } catch (SQLException e) {
             logger.error("Failed to clear missing marker for profile: {}", profileName, e);
+        }
+    }
+
+    // Pinned-profile order methods
+    public boolean isProfilePinned(String profileName) {
+        if (profileName == null) {
+            return false;
+        }
+        String sql = "SELECT 1 FROM profile_pins WHERE profile_name = ?";
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            pstmt.setString(1, profileName);
+            ResultSet rs = pstmt.executeQuery();
+            return rs.next();
+        } catch (SQLException e) {
+            logger.error("Failed to check pin state for profile: {}", profileName, e);
+            return false;
+        }
+    }
+
+    /**
+     * Pinned profile names in display order (index 0 = top).
+     */
+    public List<String> getPinnedProfilesInOrder() {
+        List<String> result = new ArrayList<>();
+        String sql = "SELECT profile_name FROM profile_pins ORDER BY pin_order ASC";
+        try (PreparedStatement pstmt = connection.prepareStatement(sql);
+             ResultSet rs = pstmt.executeQuery()) {
+            while (rs.next()) {
+                result.add(rs.getString("profile_name"));
+            }
+        } catch (SQLException e) {
+            logger.error("Failed to read pinned profile order", e);
+        }
+        return result;
+    }
+
+    public void setProfilePinned(String profileName, boolean pinned) {
+        if (profileName == null) {
+            return;
+        }
+        List<String> order = new ArrayList<>(getPinnedProfilesInOrder());
+        boolean changed = pinned ? !order.contains(profileName) && order.add(profileName)
+                                  : order.remove(profileName);
+        if (changed) {
+            setPinnedProfilesInOrder(order);
+        }
+    }
+
+    /**
+     * Replaces the entire pinned-profile set and order with the given list (index 0 = top).
+     * Any profile currently pinned but absent from newOrder becomes unpinned. Used both for
+     * a single pin/unpin toggle and for a drag-and-drop reorder, so the pinned set always
+     * comes from one authoritative write rather than incremental inserts/updates.
+     */
+    public void setPinnedProfilesInOrder(List<String> newOrder) {
+        try {
+            connection.setAutoCommit(false);
+            try (Statement del = connection.createStatement()) {
+                del.execute("DELETE FROM profile_pins");
+            }
+            try (PreparedStatement ins = connection.prepareStatement(
+                    "INSERT INTO profile_pins (profile_name, pin_order) VALUES (?, ?)")) {
+                int order = 0;
+                for (String profile : newOrder) {
+                    ins.setString(1, profile);
+                    ins.setInt(2, order++);
+                    ins.executeUpdate();
+                }
+            }
+            connection.commit();
+        } catch (SQLException e) {
+            logger.error("Failed to persist pinned profile order", e);
+            try {
+                connection.rollback();
+            } catch (SQLException rollbackEx) {
+                logger.error("Failed to roll back pinned profile order update", rollbackEx);
+            }
+        } finally {
+            try {
+                connection.setAutoCommit(true);
+            } catch (SQLException e) {
+                logger.error("Failed to restore auto-commit after pinned profile order update", e);
+            }
+        }
+    }
+
+    public void deleteProfilePin(String profileName) {
+        if (profileName == null) {
+            return;
+        }
+        String sql = "DELETE FROM profile_pins WHERE profile_name = ?";
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            pstmt.setString(1, profileName);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            logger.error("Failed to delete pin for profile: {}", profileName, e);
         }
     }
 

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -11,6 +11,9 @@ import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableRowSorter;
 import java.awt.*;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
@@ -70,6 +73,7 @@ public class SwingMain extends JFrame {
     private TrayIcon trayIcon;
     private final Map<String, Instant> lastNotifiedExpiration = new HashMap<>();
     private final Set<String> expiringSoonProfiles = new HashSet<>();
+    private final List<String> pinnedProfileOrder = new ArrayList<>();
 
     private ConfigManager configManager;
     private CredentialManager credentialManager;
@@ -176,8 +180,9 @@ public class SwingMain extends JFrame {
         tokenStatusTable = new JTable(tokenStatusTableModel);
         tokenStatusTable.setFillsViewportHeight(true);
         tokenStatusTable.setRowHeight(26);
-        tokenStatusTable.setToolTipText("Click a row to select that profile above, or right-click for actions. Click a column header to sort.");
-        tokenStatusTable.getColumnModel().getColumn(1).setCellRenderer(new StatusTableCellRenderer(expiringSoonProfiles));
+        tokenStatusTable.setToolTipText("Click a row to select that profile above, drag a row to pin/reorder favorites, "
+            + "or right-click for actions. Click a column header to sort.");
+        tokenStatusTable.setDefaultRenderer(Object.class, new StatusTableCellRenderer(expiringSoonProfiles, pinnedProfileOrder));
         tokenStatusRowSorter = new TableRowSorter<>(tokenStatusTableModel);
         tokenStatusTable.setRowSorter(tokenStatusRowSorter);
         // Single source of truth for "which profile is selected to act on": any change to the
@@ -193,6 +198,9 @@ public class SwingMain extends JFrame {
                 profileComboBox.setSelectedItem(tokenStatusTable.getValueAt(row, 0));
             }
         });
+        tokenStatusTable.setDragEnabled(true);
+        tokenStatusTable.setDropMode(DropMode.INSERT_ROWS);
+        tokenStatusTable.setTransferHandler(new ProfileRowTransferHandler());
         JPopupMenu tableContextMenu = createTableContextMenu();
         tokenStatusTable.addMouseListener(new java.awt.event.MouseAdapter() {
             @Override
@@ -673,6 +681,8 @@ public class SwingMain extends JFrame {
         try {
             tokenStatusTableModel.setRowCount(0);
             expiringSoonProfiles.clear();
+            pinnedProfileOrder.clear();
+            pinnedProfileOrder.addAll(databaseManager.getPinnedProfilesInOrder());
             List<String> availableProfiles = configManager.getAvailableProfiles();
             databaseManager.reconcileProfiles(new HashSet<>(availableProfiles));
 
@@ -712,8 +722,16 @@ public class SwingMain extends JFrame {
                 rows.add(new TokenStatusRow(profile, status, expiresAtText, timeRemaining));
             }
 
-            // Simplified sorting
+            // Pinned profiles sort to the top in their persisted order; everything else falls
+            // back to the existing status-then-name ordering.
             rows.sort((a, b) -> {
+                int rankA = pinnedProfileOrder.indexOf(a.getProfile());
+                int rankB = pinnedProfileOrder.indexOf(b.getProfile());
+                if (rankA >= 0 || rankB >= 0) {
+                    if (rankA < 0) return 1;
+                    if (rankB < 0) return -1;
+                    return rankA - rankB;
+                }
                 int statusOrder = getStatusOrder(a.getStatus()) - getStatusOrder(b.getStatus());
                 if (statusOrder != 0) return statusOrder;
                 return a.getProfile().compareTo(b.getProfile());
@@ -802,6 +820,20 @@ public class SwingMain extends JFrame {
         try {
             List<String> profiles = configManager.getAvailableProfiles();
             String lastUsedProfile = databaseManager.getLastUsedProfile();
+
+            // Pinned profiles surface first, same ordering as the status table.
+            List<String> orderedProfiles = new ArrayList<>();
+            for (String pinned : databaseManager.getPinnedProfilesInOrder()) {
+                if (profiles.contains(pinned)) {
+                    orderedProfiles.add(pinned);
+                }
+            }
+            for (String profile : profiles) {
+                if (!orderedProfiles.contains(profile)) {
+                    orderedProfiles.add(profile);
+                }
+            }
+            profiles = orderedProfiles;
 
             // JComboBox auto-selects the first added item, firing the selection listener
             // before the real last-used profile can be restored below; suppress persistence
@@ -1115,15 +1147,24 @@ public class SwingMain extends JFrame {
 
     private static class StatusTableCellRenderer extends DefaultTableCellRenderer {
         private final Set<String> expiringSoonProfiles;
+        private final List<String> pinnedProfiles;
 
-        StatusTableCellRenderer(Set<String> expiringSoonProfiles) {
+        StatusTableCellRenderer(Set<String> expiringSoonProfiles, List<String> pinnedProfiles) {
             this.expiringSoonProfiles = expiringSoonProfiles;
+            this.pinnedProfiles = pinnedProfiles;
         }
 
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
                                                        boolean hasFocus, int row, int column) {
             Component component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+
+            // Registered as the table's default renderer (all columns), so bold-face the whole
+            // pinned row rather than just the status column.
+            String rowProfile = (String) table.getValueAt(row, 0);
+            component.setFont(component.getFont().deriveFont(
+                pinnedProfiles.contains(rowProfile) ? Font.BOLD : Font.PLAIN));
+
             if (column == 1 && value instanceof String status) {
                 switch (status) {
                     case "VALID" -> {
@@ -1174,6 +1215,85 @@ public class SwingMain extends JFrame {
         }
     }
 
+    /**
+     * Drag-and-drop row reordering for the status table. Dragging a row onto another row
+     * pins the dragged profile (if not already pinned) at that position, or moves it there
+     * if it's already pinned — reordering always targets the pinned block specifically, since
+     * unpinned rows fall back to the status/name ordering refreshStatusTable() already applies.
+     */
+    private class ProfileRowTransferHandler extends TransferHandler {
+        @Override
+        public int getSourceActions(JComponent c) {
+            return MOVE;
+        }
+
+        @Override
+        protected Transferable createTransferable(JComponent c) {
+            int viewRow = tokenStatusTable.getSelectedRow();
+            if (viewRow < 0) {
+                return null;
+            }
+            return new StringSelection((String) tokenStatusTable.getValueAt(viewRow, 0));
+        }
+
+        @Override
+        public boolean canImport(TransferSupport support) {
+            // Reordering is relative to what's visually above/below the drop point, which is
+            // only well-defined against the pinned-first/status/name ordering this table
+            // normally uses — decline while a column-header sort overrides that ordering.
+            return support.isDrop()
+                && support.isDataFlavorSupported(DataFlavor.stringFlavor)
+                && tokenStatusRowSorter.getSortKeys().isEmpty();
+        }
+
+        @Override
+        public boolean importData(TransferSupport support) {
+            if (!canImport(support)) {
+                return false;
+            }
+            try {
+                String draggedProfile = (String) support.getTransferable().getTransferData(DataFlavor.stringFlavor);
+                int targetViewRow = ((JTable.DropLocation) support.getDropLocation()).getRow();
+                reorderPinnedProfile(draggedProfile, targetViewRow);
+                return true;
+            } catch (Exception ex) {
+                logger.warn("Failed to reorder pinned profile via drag-and-drop", ex);
+                return false;
+            }
+        }
+    }
+
+    private void reorderPinnedProfile(String profile, int targetViewRow) {
+        List<String> pinned = new ArrayList<>(databaseManager.getPinnedProfilesInOrder());
+        pinned.remove(profile);
+
+        int insertIndex;
+        if (targetViewRow < 0 || targetViewRow >= tokenStatusTable.getRowCount()) {
+            insertIndex = pinned.size();
+        } else {
+            String targetProfile = (String) tokenStatusTable.getValueAt(targetViewRow, 0);
+            int existingIndex = pinned.indexOf(targetProfile);
+            insertIndex = (existingIndex >= 0) ? existingIndex : pinned.size();
+        }
+
+        pinned.add(insertIndex, profile);
+        databaseManager.setPinnedProfilesInOrder(pinned);
+        statusLabel.setText("Pinned \"" + profile + "\" at position " + (insertIndex + 1) + ".");
+        refreshStatusTable();
+        loadProfiles();
+    }
+
+    private void toggleProfilePinned(String profileName) {
+        if (profileName == null) {
+            return;
+        }
+        boolean pinned = databaseManager.isProfilePinned(profileName);
+        databaseManager.setProfilePinned(profileName, !pinned);
+        statusLabel.setText((!pinned ? "Pinned \"" : "Unpinned \"") + profileName + "\".");
+        refreshStatusTable();
+        loadProfiles();
+    }
+
     private JPopupMenu createTableContextMenu() {
         JPopupMenu menu = new JPopupMenu();
 
@@ -1195,6 +1315,12 @@ public class SwingMain extends JFrame {
 
         menu.addSeparator();
 
+        JMenuItem pinItem = new JMenuItem("Pin Profile");
+        pinItem.addActionListener(e -> toggleProfilePinned(contextMenuTargetProfile));
+        menu.add(pinItem);
+
+        menu.addSeparator();
+
         JMenuItem deleteItem = new JMenuItem("Delete Profile...");
         deleteItem.addActionListener(e -> deleteProfileFromContextMenu(contextMenuTargetProfile));
         menu.add(deleteItem);
@@ -1211,6 +1337,9 @@ public class SwingMain extends JFrame {
                 showItem.setEnabled(hasCredentials);
                 showEncryptedItem.setEnabled(hasCredentials && hasPublicKey);
                 openConsoleItem.setEnabled(hasCredentials);
+                pinItem.setText(profile != null && databaseManager.isProfilePinned(profile)
+                    ? "Unpin Profile" : "Pin Profile");
+                pinItem.setEnabled(profile != null);
                 deleteItem.setEnabled(profile != null);
             }
 

--- a/src/test/java/com/ourgiant/saml/DatabaseManagerTest.java
+++ b/src/test/java/com/ourgiant/saml/DatabaseManagerTest.java
@@ -12,11 +12,14 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DatabaseManagerTest {
 
@@ -139,5 +142,48 @@ class DatabaseManagerTest {
         databaseManager.updateExpiration("foo", Instant.now().plusSeconds(3600));
         databaseManager.reconcileProfiles(Set.of(), false);
         assertNotNull(readMissingSince("foo"));
+    }
+
+    @Test
+    void setProfilePinned_pinsAndUnpinsProfile() {
+        assertFalse(databaseManager.isProfilePinned("foo"));
+
+        databaseManager.setProfilePinned("foo", true);
+        assertTrue(databaseManager.isProfilePinned("foo"));
+        assertEquals(List.of("foo"), databaseManager.getPinnedProfilesInOrder());
+
+        databaseManager.setProfilePinned("foo", false);
+        assertFalse(databaseManager.isProfilePinned("foo"));
+        assertEquals(List.of(), databaseManager.getPinnedProfilesInOrder());
+    }
+
+    @Test
+    void setProfilePinned_appendsNewPinsAtEnd() {
+        databaseManager.setProfilePinned("a", true);
+        databaseManager.setProfilePinned("b", true);
+
+        assertEquals(List.of("a", "b"), databaseManager.getPinnedProfilesInOrder());
+    }
+
+    @Test
+    void setPinnedProfilesInOrder_replacesEntirePinnedSet() {
+        databaseManager.setProfilePinned("a", true);
+        databaseManager.setProfilePinned("b", true);
+        databaseManager.setProfilePinned("c", true);
+
+        databaseManager.setPinnedProfilesInOrder(List.of("c", "a"));
+
+        assertEquals(List.of("c", "a"), databaseManager.getPinnedProfilesInOrder());
+        assertFalse(databaseManager.isProfilePinned("b"), "b was omitted from the replacement order, so it should be unpinned");
+    }
+
+    @Test
+    void reconcileProfiles_forceImmediate_alsoPrunesPins() {
+        databaseManager.updateExpiration("stale", Instant.now().plusSeconds(3600));
+        databaseManager.setProfilePinned("stale", true);
+
+        databaseManager.reconcileProfiles(Set.of(), true);
+
+        assertFalse(databaseManager.isProfilePinned("stale"));
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #116: with "any number of AWS profiles" supported, someone with a large account list has to scan/filter past rarely-used profiles to reach the ones they touch daily. Adds pinning + drag-and-drop reordering so favorites surface first in both the status table and the profile combo box.
- **Pinning**: a "Pin Profile"/"Unpin Profile" context menu toggle (dynamic label based on current state). Pinned profiles sort to the top of both the status table and the combo box, in a persisted order, ahead of the existing status-then-name ordering. Pinned rows render bold as a visual cue (table's default renderer now covers all 4 columns, not just the status column, so the whole row bolds).
- **Drag-and-drop reorder**: dragging a table row onto another row reorders it within the pinned block, auto-pinning it there if it wasn't already pinned — dragging is both "promote to favorite" and "control its position," rather than a separate reorder-only mode. Declines the drop while a column-header sort is active (`tokenStatusRowSorter.getSortKeys()` non-empty), since the drop position is only meaningful against the table's normal pinned/status/name ordering.
- **Persistence**: new `profile_pins` table in `DatabaseManager` (`profile_name` + `pin_order`), with `setPinnedProfilesInOrder(List<String>)` as the single authoritative write (full replace) used by both a single toggle and a drag reorder. Hooked into the existing `reconcileProfiles()` grace-period pruning (same call sites as `token_state`), so a pin doesn't outlive a profile's removal from `samlsts`.

## Test plan
- [x] `mvn test` — full suite passes, including 4 new `DatabaseManagerTest` cases: pin/unpin round-trip, append-order for new pins, `setPinnedProfilesInOrder` full-replace semantics (omitted profile becomes unpinned), and pin pruning via `reconcileProfiles(..., true)`.
- [x] Verified live in the running app via a reflection-driven harness exercising the actual `SwingMain` methods the UI calls (`toggleProfilePinned`, `reorderPinnedProfile`) against a real `JTable`/`JComboBox`:
  - Initial state: alphabetical, nothing pinned.
  - Pin `beta-profile` then `gamma-profile`: both the table and combo box reorder to `[beta, gamma, alpha, delta]`; bold-check confirms `beta`/`gamma` render bold, `alpha` doesn't.
  - Drag `alpha-profile` onto position 0: auto-pins it at the top → `[alpha, beta, gamma, delta]`, table and combo box stay in sync.
  - Unpin `beta-profile`: drops to the unpinned block in alphabetical order → `[alpha, gamma, beta, delta]`, remaining pin order (`alpha`, `gamma`) preserved.
- [x] Patch version bumped 1.3.5 → 1.3.6 per this repo's `ship-issue` convention.