### PR TITLE
Move batch refresh out of the main toolbar into a menu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.6</version>
+    <version>1.3.7</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -51,7 +51,8 @@ public class SwingMain extends JFrame {
     private JButton showEncryptedButton;
     private JButton showCredentialsButton;
     private JButton openConsoleButton;
-    private JButton batchRefreshButton;
+    private JMenuItem batchRefreshMenuItem;
+    private JButton batchCancelButton;
 
     private DefaultTableModel tokenStatusTableModel;
     private JTable tokenStatusTable;
@@ -269,13 +270,6 @@ public class SwingMain extends JFrame {
         refreshStatusButton.addActionListener(e -> refreshStatusTable());
         refreshStatusButton.setToolTipText("Recheck credential expiration status for all profiles");
         statusControls.add(refreshStatusButton);
-
-        batchRefreshButton = new JButton("Refresh Expiring/Expired");
-        batchRefreshButton.setMnemonic(KeyEvent.VK_E);
-        batchRefreshButton.addActionListener(new BatchRefreshListener());
-        batchRefreshButton.setToolTipText("Renew credentials (via browser login) for every profile that's "
-            + "expired or within " + formatDuration(EXPIRY_WARNING_THRESHOLD) + " of expiring");
-        statusControls.add(batchRefreshButton);
         lastRefreshedLabel = new JLabel();
         statusControls.add(lastRefreshedLabel);
         tokenStatusPanel.add(statusControls, BorderLayout.SOUTH);
@@ -294,6 +288,14 @@ public class SwingMain extends JFrame {
         loginProgressBar.setIndeterminate(true);
         loginProgressBar.setVisible(false);
         statusPanel.add(loginProgressBar);
+        // Only shown while a batch refresh is actually running (see
+        // refreshExpiringOrExpiredProfiles()), so cancelling stays a single visible click away
+        // in the moment it matters without giving the batch action a permanent seat on the
+        // main screen the rest of the time.
+        batchCancelButton = new JButton("Cancel Batch Refresh");
+        batchCancelButton.addActionListener(e -> cancelCredentialRequest());
+        batchCancelButton.setVisible(false);
+        statusPanel.add(batchCancelButton);
         add(statusPanel, BorderLayout.SOUTH);
 
         pack();
@@ -334,6 +336,19 @@ public class SwingMain extends JFrame {
         fileMenu.add(exitMenuItem);
 
         menuBar.add(fileMenu);
+
+        JMenu actionsMenu = new JMenu("Actions");
+        actionsMenu.setMnemonic(KeyEvent.VK_A);
+
+        batchRefreshMenuItem = new JMenuItem("Refresh Expiring/Expired Profiles...");
+        batchRefreshMenuItem.setMnemonic(KeyEvent.VK_E);
+        batchRefreshMenuItem.addActionListener(e -> refreshExpiringOrExpiredProfiles());
+        batchRefreshMenuItem.setToolTipText("Renew credentials (via browser login) for every profile that's "
+            + "expired or within " + formatDuration(EXPIRY_WARNING_THRESHOLD) + " of expiring");
+        actionsMenu.add(batchRefreshMenuItem);
+
+        menuBar.add(actionsMenu);
+
         return menuBar;
     }
 
@@ -899,7 +914,7 @@ public class SwingMain extends JFrame {
         // Swap the button to a Cancel affordance during processing
         requestCredentialsButton.setText("Cancel");
         requestCredentialsButton.setToolTipText("Cancel the in-progress credential request");
-        batchRefreshButton.setEnabled(false);
+        batchRefreshMenuItem.setEnabled(false);
         credentialRequestInProgress = true;
         credentialRequestCancelledByUser = false;
         loginProgressBar.setVisible(true);
@@ -925,7 +940,7 @@ public class SwingMain extends JFrame {
             protected void done() {
                 requestCredentialsButton.setText("Request Credentials");
                 requestCredentialsButton.setToolTipText("Launch browser login and fetch AWS credentials for the selected profile");
-                batchRefreshButton.setEnabled(true);
+                batchRefreshMenuItem.setEnabled(true);
                 credentialRequestInProgress = false;
                 loginProgressBar.setVisible(false);
                 activeAuthenticator = null;
@@ -959,17 +974,6 @@ public class SwingMain extends JFrame {
         credentialRequestCancelledByUser = true;
         if (activeAuthenticator != null) {
             activeAuthenticator.cancel();
-        }
-    }
-
-    private class BatchRefreshListener implements ActionListener {
-        @Override
-        public void actionPerformed(ActionEvent e) {
-            if (credentialRequestInProgress) {
-                cancelCredentialRequest();
-            } else {
-                refreshExpiringOrExpiredProfiles();
-            }
         }
     }
 
@@ -1010,8 +1014,17 @@ public class SwingMain extends JFrame {
             return;
         }
 
-        batchRefreshButton.setText("Cancel");
-        batchRefreshButton.setToolTipText("Cancel the in-progress batch refresh");
+        int confirm = JOptionPane.showConfirmDialog(SwingMain.this,
+            "This will refresh " + targets.size() + " profile(s) via browser login, one at a time. Continue?",
+            "Refresh Expiring/Expired Profiles",
+            JOptionPane.YES_NO_OPTION,
+            JOptionPane.QUESTION_MESSAGE);
+        if (confirm != JOptionPane.YES_OPTION) {
+            return;
+        }
+
+        batchRefreshMenuItem.setEnabled(false);
+        batchCancelButton.setVisible(true);
         requestCredentialsButton.setEnabled(false);
         credentialRequestInProgress = true;
         credentialRequestCancelledByUser = false;
@@ -1063,9 +1076,8 @@ public class SwingMain extends JFrame {
 
             @Override
             protected void done() {
-                batchRefreshButton.setText("Refresh Expiring/Expired");
-                batchRefreshButton.setToolTipText("Renew credentials (via browser login) for every profile that's "
-                    + "expired or within " + formatDuration(EXPIRY_WARNING_THRESHOLD) + " of expiring");
+                batchRefreshMenuItem.setEnabled(true);
+                batchCancelButton.setVisible(false);
                 requestCredentialsButton.setEnabled(true);
                 credentialRequestInProgress = false;
                 loginProgressBar.setVisible(false);


### PR DESCRIPTION
## Summary
- Fixes #123: `batchRefreshButton` ("Refresh Expiring/Expired") and `refreshStatusButton` ("Refresh Status") sat side by side in the main toolbar with matching size/weight, despite wildly different blast radius — one is a free, instant, read-only local refresh; the other launches real sequential browser SAML logins across every stale profile. Surfaced during UAT: confusion about which button had actually triggered a 17-profile batch run.
- Moves the batch action to a new **Actions** menu (`batchRefreshMenuItem`); **Refresh Status stays on the main screen** since it's cheap and side-effect-free, per your explicit call to keep it there.
- Adds a confirmation dialog before the batch starts — "This will refresh N profile(s) via browser login, one at a time. Continue?" — mirroring this app's existing "Delete Profile..." confirmation pattern. Previously the only interruption was an info dialog when there was *nothing* to refresh; a real N-profile run had no gate at all.
- Since starting the batch now means leaving the main screen (menu) and confirming, the in-place "Cancel" toggle that lived on the toolbar button moves too: a dedicated "Cancel Batch Refresh" button now appears in the status bar next to the progress bar **only while a batch is actually running**, rather than permanently occupying screen space. Single-profile "Request Credentials" keeps its existing in-place Cancel behavior unchanged.
- Removed the now-dead `BatchRefreshListener` inner class (its cancel-toggle branch is unreachable now that the menu item is disabled mid-run — cancellation exclusively goes through the new dedicated button).

## Test plan
- [x] `mvn test` — full suite passes.
- [x] Verified live via a reflection-driven harness:
  - Confirmed no batch-refresh `JButton` remains anywhere in the main window; confirmed the menu bar now has `File` + `Actions`, with "Refresh Expiring/Expired Profiles..." under `Actions`.
  - Clicking the menu item shows the confirmation dialog with the correct profile count; clicking **No** leaves everything untouched (menu item stays enabled, cancel button stays hidden) — no batch starts.
  - Clicking **Yes** with a slow-failing test IdP (so the run doesn't finish before it can be observed) confirmed the mid-run state: `batchRefreshMenuItem` disabled, `batchCancelButton` visible.
  - Clicking "Cancel Batch Refresh" mid-run correctly propagates `CancellationException` (same underlying `cancelCredentialRequest()` path as the single-profile flow) and resets both back to idle (menu item re-enabled, cancel button hidden).
- [x] Patch version bumped 1.3.6 → 1.3.7 per this repo's `ship-issue` convention.