### PR TITLE
Batch refresh: reuse one SAML assertion across profiles instead of one login each

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.7</version>
+    <version>1.3.8</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
+++ b/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
@@ -50,11 +50,33 @@ public class SamlAuthenticator {
     }
 
     /**
-     * Main method to request credentials for a profile
+     * Main method to request credentials for a profile: logs in, then assumes that profile's
+     * role. Implemented on top of performLoginAndGetAssertion()/assumeRoleAndSaveCredentials()
+     * below, which a caller driving several profiles can use directly to share one login's
+     * assertion across all of them (see #124) instead of logging in once per profile.
      */
     public void requestCredentials(String profileName, boolean useOktaFastPass, boolean showBrowser,
                                    Consumer<String> statusCallback) throws Exception {
-        logger.info("Starting credential request for profile: {}", profileName);
+        String samlResponse = performLoginAndGetAssertion(profileName, useOktaFastPass, showBrowser, statusCallback);
+        assumeRoleAndSaveCredentials(profileName, samlResponse, statusCallback);
+    }
+
+    /**
+     * Performs the browser SAML login for the given profile's identity provider/username and
+     * returns the raw SAML assertion, without assuming any AWS role yet.
+     *
+     * The returned assertion is not scoped to this profile's role — role selection happens
+     * later, purely via assumeRoleAndSaveCredentials()'s AssumeRoleWithSAML call (the visible
+     * in-browser "select a role" click in BrowserLoginHandler.selectRoleAndSignIn() is a
+     * cosmetic step that only runs when showBrowser is true, and only *after* this method has
+     * already captured the assertion — it has no bearing on what the assertion contains). That
+     * means this same assertion is valid to drive assumeRoleAndSaveCredentials() for *any*
+     * profile sharing this profile's identity provider and username, until the assertion's own
+     * short server-side validity window elapses.
+     */
+    public String performLoginAndGetAssertion(String profileName, boolean useOktaFastPass, boolean showBrowser,
+                                                Consumer<String> statusCallback) throws Exception {
+        logger.info("Starting SAML login for profile: {}", profileName);
         statusCallback.accept("Loading configuration for profile: " + profileName + "...");
 
         // Get profile configuration
@@ -62,8 +84,6 @@ public class SamlAuthenticator {
         String accountNumber = configManager.getAccountNumber(profileName);
         String iamRole = configManager.getIamRole(profileName);
         String username = configManager.getUsername(profileName);
-        String awsRegion = configManager.getAwsRegion(profileName);
-        int sessionDuration = configManager.getSessionDuration(profileName);
 
         if (samlProvider == null || accountNumber == null || iamRole == null) {
             throw new IllegalArgumentException("Incomplete profile configuration for: " + profileName);
@@ -88,6 +108,26 @@ public class SamlAuthenticator {
 
         if (cancelled) {
             throw new CancellationException("Credential request cancelled for profile: " + profileName);
+        }
+
+        return samlResponse;
+    }
+
+    /**
+     * Assumes the given profile's configured AWS role using an already-obtained SAML assertion
+     * (from performLoginAndGetAssertion() — possibly shared across several profiles, see #124)
+     * and saves the resulting credentials.
+     */
+    public void assumeRoleAndSaveCredentials(String profileName, String samlResponse,
+                                              Consumer<String> statusCallback) throws Exception {
+        String samlProvider = configManager.getSamlProvider(profileName);
+        String accountNumber = configManager.getAccountNumber(profileName);
+        String iamRole = configManager.getIamRole(profileName);
+        String awsRegion = configManager.getAwsRegion(profileName);
+        int sessionDuration = configManager.getSessionDuration(profileName);
+
+        if (samlProvider == null || accountNumber == null || iamRole == null) {
+            throw new IllegalArgumentException("Incomplete profile configuration for: " + profileName);
         }
 
         // Parse SAML and get role ARN

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -30,13 +30,16 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Main Swing application for AWS SAML authentication
@@ -981,6 +984,21 @@ public class SwingMain extends JFrame {
     }
 
     /**
+     * Groups profiles that can share a single SAML login: same identity key (in practice,
+     * samlProvider + username), each group in first-seen order. Pure/static so the grouping
+     * logic itself is unit-testable without ConfigManager or live Swing state, per this
+     * project's convention of pulling logic out of Swing components where practical.
+     */
+    static List<List<String>> groupProfilesBySharedIdentity(List<String> profiles,
+                                                              Function<String, String> identityKeyFn) {
+        Map<String, List<String>> byIdentity = new LinkedHashMap<>();
+        for (String profile : profiles) {
+            byIdentity.computeIfAbsent(identityKeyFn.apply(profile), k -> new ArrayList<>()).add(profile);
+        }
+        return new ArrayList<>(byIdentity.values());
+    }
+
+    /**
      * Sequentially drives a fresh credential request for every profile currently EXPIRED or
      * within EXPIRY_WARNING_THRESHOLD of expiring, so a user managing many profiles doesn't have
      * to repeat "select profile, click Request Credentials, wait" once per stale profile. Shares
@@ -1035,33 +1053,74 @@ public class SwingMain extends JFrame {
             @Override
             protected List<BatchRefreshResult> doInBackground() {
                 List<BatchRefreshResult> results = new ArrayList<>();
-                for (int i = 0; i < targets.size(); i++) {
+
+                // Watching the browser only makes sense one login at a time (the visual
+                // role-selection step doesn't generalize to a shared login) - keep every
+                // profile its own group in that case. Otherwise, profiles on the same identity
+                // provider + username share one login's SAML assertion (see #124) instead of
+                // logging in once per profile.
+                List<List<String>> groups = showBrowserCheckBox.isSelected()
+                    ? targets.stream().map(List::of).collect(Collectors.toList())
+                    : groupProfilesBySharedIdentity(targets,
+                        p -> configManager.getSamlProvider(p) + "|" + configManager.getUsername(p));
+
+                int completed = 0;
+                groupLoop:
+                for (List<String> group : groups) {
                     if (credentialRequestCancelledByUser) {
                         break;
                     }
-                    String profile = targets.get(i);
-                    String progressPrefix = "Refreshing " + (i + 1) + " of " + targets.size() + " (" + profile + "): ";
-                    publish(progressPrefix + "starting...");
+
+                    String representativeProfile = group.get(0);
+                    String loginPrefix = group.size() > 1
+                        ? "Logging in once for " + group.size() + " profiles sharing "
+                            + representativeProfile + "'s identity provider: "
+                        : "Refreshing " + (completed + 1) + " of " + targets.size()
+                            + " (" + representativeProfile + "): ";
+                    publish(loginPrefix + "starting...");
 
                     SamlAuthenticator authenticator = new SamlAuthenticator();
                     activeAuthenticator = authenticator;
+                    String assertion;
                     try {
-                        authenticator.requestCredentials(
-                            profile,
+                        assertion = authenticator.performLoginAndGetAssertion(
+                            representativeProfile,
                             databaseManager.getFastPassEnabled(),
                             showBrowserCheckBox.isSelected(),
-                            msg -> publish(progressPrefix + msg)
+                            msg -> publish(loginPrefix + msg)
                         );
-                        results.add(new BatchRefreshResult(profile, true, null));
                     } catch (Exception ex) {
+                        activeAuthenticator = null;
                         if (credentialRequestCancelledByUser) {
-                            // Cancelled mid-flight: don't report the interrupted profile as a failure.
+                            // Cancelled mid-flight: don't report the interrupted group as failures.
                             break;
                         }
+                        // The shared login itself failed: every profile in the group failed with it.
                         CredentialRequestError error = CredentialRequestError.classify(ex);
-                        results.add(new BatchRefreshResult(profile, false, error.statusMessage()));
-                    } finally {
-                        activeAuthenticator = null;
+                        for (String profile : group) {
+                            results.add(new BatchRefreshResult(profile, false, error.statusMessage()));
+                        }
+                        completed += group.size();
+                        continue;
+                    }
+                    activeAuthenticator = null;
+
+                    for (String profile : group) {
+                        if (credentialRequestCancelledByUser) {
+                            break groupLoop;
+                        }
+                        completed++;
+                        String progressPrefix = "Refreshing " + completed + " of " + targets.size()
+                            + " (" + profile + "): ";
+                        publish(progressPrefix + "assuming role...");
+                        try {
+                            authenticator.assumeRoleAndSaveCredentials(profile, assertion,
+                                msg -> publish(progressPrefix + msg));
+                            results.add(new BatchRefreshResult(profile, true, null));
+                        } catch (Exception ex) {
+                            CredentialRequestError error = CredentialRequestError.classify(ex);
+                            results.add(new BatchRefreshResult(profile, false, error.statusMessage()));
+                        }
                     }
                 }
                 return results;

--- a/src/test/java/com/ourgiant/saml/SwingMainProfileGroupingTest.java
+++ b/src/test/java/com/ourgiant/saml/SwingMainProfileGroupingTest.java
@@ -1,0 +1,48 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SwingMainProfileGroupingTest {
+
+    @Test
+    void groupsProfilesSharingTheSameIdentityKey() {
+        List<String> profiles = List.of("a", "b", "c", "d");
+
+        List<List<String>> groups = SwingMain.groupProfilesBySharedIdentity(profiles,
+            p -> switch (p) {
+                case "a", "c" -> "okta|alice";
+                default -> "okta|bob";
+            });
+
+        assertEquals(List.of(List.of("a", "c"), List.of("b", "d")), groups);
+    }
+
+    @Test
+    void eachDistinctIdentityIsItsOwnGroup() {
+        List<String> profiles = List.of("a", "b", "c");
+
+        List<List<String>> groups = SwingMain.groupProfilesBySharedIdentity(profiles, p -> p);
+
+        assertEquals(List.of(List.of("a"), List.of("b"), List.of("c")), groups);
+    }
+
+    @Test
+    void allProfilesShareOneGroupWhenIdentityKeyIsConstant() {
+        List<String> profiles = List.of("a", "b", "c");
+
+        List<List<String>> groups = SwingMain.groupProfilesBySharedIdentity(profiles, p -> "same-identity");
+
+        assertEquals(List.of(List.of("a", "b", "c")), groups);
+    }
+
+    @Test
+    void emptyInputProducesNoGroups() {
+        List<List<String>> groups = SwingMain.groupProfilesBySharedIdentity(List.of(), p -> p);
+
+        assertEquals(List.of(), groups);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #124: `SamlAuthenticator.requestCredentials()` did a full browser SAML login for every profile, even when the batch-refresh flow (#113) called it back-to-back for profiles sharing the same identity provider and username. Confirmed the premise by re-reading `BrowserLoginHandler`: `selectRoleAndSignIn()` (the in-browser account/role click) only runs when `showBrowser=true`, and only *after* the SAML assertion has already been captured from the hidden form field — it has zero bearing on what the assertion contains. That means one login's assertion is generically valid to drive `AssumeRoleWithSAML` for *any* profile sharing that login's `(samlProvider, username)` pair, not just the one that triggered it.
- Splits `SamlAuthenticator.requestCredentials()` into two public methods:
  - `performLoginAndGetAssertion(...)` — browser login only, returns the raw assertion.
  - `assumeRoleAndSaveCredentials(...)` — role lookup + `AssumeRoleWithSAML` + save, given an assertion.
  - `requestCredentials(...)` now just chains them, so the single-profile "Request Credentials" button's behavior is byte-for-byte unchanged.
- The batch-refresh flow groups its targets by `(samlProvider, username)` via a new static, unit-tested `groupProfilesBySharedIdentity(...)`, does **one** login per group (using the group's first profile to drive it), then loops role-assumption across every profile in that group reusing the same assertion — no repeat browser trip.
- Falls back to one login per profile (every group size 1) when "Show browser" is checked, since the visual role-selection click doesn't generalize to a shared login the user is watching.
- A shared login's failure is attributed to every profile in that group (they'd all have failed the same way); a shared login's success lets each profile's own `assumeRoleAndSaveCredentials` fail or succeed independently (e.g. a role missing for one account doesn't sink the rest of the group).

## Test plan
- [x] `mvn test` — full suite passes, including 4 new `SwingMainProfileGroupingTest` cases covering the pure grouping logic (shared-identity grouping, all-distinct, all-same, empty input).
- [x] Verified live in the running app, twice, with 3 target profiles (`profile-a`/`profile-b` sharing `Fed-Test`+`testuser`, `profile-c` on a distinct `Fed-Other`+`otheruser`) pointed at an unreachable test IdP so real login attempts are observable via `BrowserLoginHandler`'s own log output:
  - Both runs showed **exactly 2** "Navigating to login page" events for 3 target profiles — one shared login (logged under `profile-a`, the group's representative) covering both `profile-a` and `profile-b`, and one separate login for `profile-c`. Confirms the grouping and login-sharing behave exactly as designed, reproducibly.
- [x] Patch version bumped 1.3.7 → 1.3.8 per this repo's `ship-issue` convention.