### PR TITLE
Fix batch refresh error dialog overflowing the screen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.9</version>
+    <version>1.3.10</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
@@ -74,8 +74,26 @@ public class BrowserLoginHandler {
 
         } catch (Exception e) {
             logger.error("Login failed", e);
-            throw new RuntimeException("Login process failed: " + e.getMessage(), e);
+            throw new RuntimeException("Login process failed: " + summarize(e.getMessage()), e);
         }
+    }
+
+    /**
+     * Selenium's own exceptions (TimeoutException in particular) pack a multi-line dump —
+     * build info, full System/Driver info, the entire Capabilities map, session ID — into
+     * getMessage() for debugging purposes. That's exactly what the full exception (preserved
+     * as this RuntimeException's cause, and already logged in full above) is for; the
+     * *message* propagated up to the user-facing error dialog only needs the actual failure
+     * summary, which is everything before that dump begins ("Build info: ..." is a reliable
+     * marker for where it starts, per WebDriverException's own message-building convention).
+     */
+    private static String summarize(String message) {
+        if (message == null) {
+            return "unknown error";
+        }
+        int buildInfoStart = message.indexOf("\nBuild info:");
+        String summary = buildInfoStart >= 0 ? message.substring(0, buildInfoStart) : message;
+        return summary.strip();
     }
 
     /**

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -1047,6 +1047,25 @@ public class SwingMain extends JFrame {
     }
 
     /**
+     * Wraps a potentially long message (e.g. several failed profiles' error detail
+     * concatenated together) in a fixed-size scrollable text area, so a verbose message can
+     * never make the dialog itself taller than the screen - the content scrolls instead.
+     */
+    private static JScrollPane scrollableMessage(String text) {
+        JTextArea textArea = new JTextArea(text);
+        textArea.setEditable(false);
+        textArea.setLineWrap(true);
+        textArea.setWrapStyleWord(true);
+        textArea.setCaretPosition(0);
+        textArea.setBackground(UIManager.getColor("OptionPane.background"));
+        textArea.setFont(UIManager.getFont("OptionPane.messageFont"));
+        JScrollPane scrollPane = new JScrollPane(textArea);
+        scrollPane.setPreferredSize(new Dimension(500, 300));
+        scrollPane.setBorder(BorderFactory.createEmptyBorder());
+        return scrollPane;
+    }
+
+    /**
      * Shared by refreshExpiringOrExpiredProfiles() and refreshSelectedProfiles() (#127):
      * confirms with the user, then sequentially drives a fresh credential request for every
      * given profile, sharing one SAML login per (samlProvider, username) group (#124). Shares
@@ -1224,7 +1243,7 @@ public class SwingMain extends JFrame {
                         detail.append("\n- ").append(r.profile()).append(": ").append(r.detail());
                     }
                     JOptionPane.showMessageDialog(SwingMain.this,
-                        detail.toString(),
+                        scrollableMessage(detail.toString()),
                         cancelled ? "Batch Refresh Cancelled" : "Batch Refresh Complete With Errors",
                         JOptionPane.WARNING_MESSAGE);
                 }


### PR DESCRIPTION
## Summary
- Fixes #129, reported during UAT: "Refresh Selected Profiles" against 3 real profiles (grouped into one shared login per #124, since they share an identity provider) failed, and the "Batch Refresh Complete With Errors" dialog rendered far taller than the screen — the same huge error text repeated once per profile in the group.
- Root cause: `BrowserLoginHandler.performLogin()`'s catch block did `"Login process failed: " + e.getMessage()`. Selenium's own exceptions (`TimeoutException` in particular) pack a multi-line debugging dump into `getMessage()` — build info, System/Driver info, the entire Capabilities map, session ID — meant for developers, not end users. That whole blob flowed straight through `CredentialRequestError` into the batch summary dialog, multiplied by every profile sharing the failing login.
- Trims the propagated message at Selenium's own `"Build info:"` marker, keeping the actual failure summary plus the useful `"(tried for N seconds...)"` duration context while dropping everything after. The full original exception is still preserved as the cause and fully logged via `logger.error(...)` — nothing lost for debugging, only the user-facing message is cleaned up.
- Also renders the batch summary dialog's detail text in a fixed-size (500x300) scrollable `JTextArea`/`JScrollPane` instead of a raw `String`, so no future verbose message — from this or any other source — can make the dialog taller than the screen again.
- Note: this doesn't address *why* the underlying login timed out against the real IdP in the report — that's a separate, unconfirmed root cause (could be a genuinely slow corporate network needing more than the current 30s wait, or something IdP-specific) being tracked separately with the user before making a speculative change to the timeout itself.

## Test plan
- [x] `mvn test` — full suite passes.
- [x] Verified live via a reflection-driven harness reproducing a 2-profile shared-login failure end-to-end:
  - Dialog now reports a bounded `500x300` preferred size regardless of failure count.
  - Rendered text contains neither `"Build info:"`, `"Capabilities {"`, nor `"Session ID:"` — just `"Login Timed Out: Login process failed: Expected condition failed: waiting for ... (tried for 30 seconds with 500 milliseconds interval)"` per profile.
- [x] Patch version bumped 1.3.9 → 1.3.10 per this repo's `ship-issue` convention.