### PR TITLE
Increase login-page wait timeout from 30s to 60s

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.10</version>
+    <version>1.3.11</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
@@ -34,7 +34,14 @@ public class BrowserLoginHandler {
                                 boolean showBrowser, String accountNumber, String iamRole,
                                 Consumer<String> statusCallback, BooleanSupplier cancelled) {
         this.driver = driver;
-        this.wait = new WebDriverWait(driver, Duration.ofSeconds(30));
+        // 30s was too tight for a slow/cold first navigation against at least one real-world
+        // corporate IdP (#132): a login attempt timed out waiting for the login page's title,
+        // then the very next attempt against the identical URL reached the next step in ~4s.
+        // This is the wait behind the critical-path title/element checks in
+        // performLogin()/handleOktaLogin()/waitForSamlResponse() - the various short "probe"
+        // waits elsewhere in this class (3s/5s/10s, used to detect *optional* page states) are
+        // deliberately short by design and untouched here.
+        this.wait = new WebDriverWait(driver, Duration.ofSeconds(60));
         this.useOktaFastPass = useOktaFastPass;
         this.passwordManager = passwordManager;
         this.showBrowser = showBrowser;


### PR DESCRIPTION
## Summary
- Fixes #132: diagnosed with the user during UAT. A real credential request (via "Refresh Selected Profiles" with one profile picked — confirmed by the failing attempt's stack trace tracing through the shared batch-runner `SwingWorker`, same code path "Request Credentials" uses) timed out waiting for the Okta login page's title after 30s. The very next attempt against the identical URL — via the standalone "Request Credentials" button — reached "Handling Okta login" in ~4s and completed successfully end to end.
- Since both attempts go through the exact same `SamlAuthenticator.performLoginAndGetAssertion()` → `BrowserLoginHandler.performLogin()` path, this rules out a batch/grouping-specific regression (#124) — it's this environment/IdP occasionally needing more than 30s for a cold first navigation (DNS, corporate VPN/proxy handshake, Okta cold start).
- Bumps only `BrowserLoginHandler`'s primary `WebDriverWait` (30s → 60s), used for the critical-path title/element waits in `performLogin`/`handleOktaLogin`/`waitForSamlResponse`. The various short "probe" waits (3s/5s/10s) used to detect *optional* page states (intermediate verification page, pre-authenticated MFA screen, etc.) are deliberately short by design and untouched.

## Test plan
- [x] `mvn test` — full suite passes.
- [x] Single `Duration` constant change to a wait mechanism already exercised extensively across this session's #113/#123/#124/#129 live verifications — no new behavior requiring a fresh synthetic harness. Root cause and fix direction confirmed directly against real UAT logs rather than a guess.
- [x] Patch version bumped 1.3.10 → 1.3.11 per this repo's `ship-issue` convention.