### PR TITLE
Log page state/screenshot on login failure; fix status bar layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ safe XPath string literals (`toXPathLiteral`, splitting on embedded quote
 characters and concatenating them back together) before being placed into
 the query.
 
+**Login-failure diagnostics** (`BrowserLoginHandler`): when a browser login
+step fails, the app logs the page's URL/title and saves a screenshot to
+`~/.aws/login-failure-screenshots/` — the same capture-on-failure technique
+the sibling Python app's `ScreenshotRecorder` uses — so a failure caused by
+an unexpected page (a device-trust check, a bot-check, an IdP redirect hop)
+is something a user or support engineer can actually look at rather than
+inferring blind from a timeout message. This only fires on an actual
+failure, not routinely, and a corporate SSO page can itself contain
+identifying information (company branding, the logged-in username) worth
+being aware of — saved screenshots get the same owner-only file permissions
+as the credentials file.
+
 **Explicitly out of scope**: this app doesn't attempt to defend against a
 compromise of the local OS user account it runs as — file permissions and
 the encryption above raise the bar against *other* accounts, processes, or

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.11</version>
+    <version>1.3.12</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
@@ -7,7 +7,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.concurrent.CancellationException;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -81,7 +87,51 @@ public class BrowserLoginHandler {
 
         } catch (Exception e) {
             logger.error("Login failed", e);
+            logPageStateOnFailure();
             throw new RuntimeException("Login process failed: " + summarize(e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Captures the page Selenium was actually looking at when a login step failed, so a
+     * timeout can be diagnosed as "page loaded but the expected condition never matched"
+     * (wrong page — an unexpected redirect hop, device-trust check, bot-check on a fresh
+     * headless fingerprint, etc.) versus "the right page just loaded slowly" instead of
+     * guessing (#134). Best-effort: driver state can itself be unusable after some failures
+     * (a crashed browser, a closed window), so this must never throw past a log warning.
+     */
+    private void logPageStateOnFailure() {
+        try {
+            logger.error("Page state at failure — URL: {}, Title: {}", driver.getCurrentUrl(), driver.getTitle());
+        } catch (Exception e) {
+            logger.warn("Could not capture page state after login failure", e);
+        }
+        captureFailureScreenshot();
+    }
+
+    /**
+     * Best-effort screenshot of the page Selenium was looking at when a login step failed —
+     * the same technique (capture-on-failure, never block/throw past a log warning) the
+     * sibling Python app's ScreenshotRecorder uses. A URL/title alone can't show a device-trust
+     * check, bot-check, or other unexpected page a user can only make sense of by looking at
+     * it. Works fine headless: Selenium's screenshot goes through the browser's own rendering
+     * via CDP, not the host display server (unlike java.awt.Robot elsewhere in this app).
+     */
+    private void captureFailureScreenshot() {
+        if (!(driver instanceof TakesScreenshot)) {
+            return;
+        }
+        try {
+            Path dir = Paths.get(System.getProperty("user.home"), ".aws", "login-failure-screenshots");
+            Files.createDirectories(dir);
+            String filename = "login-failure-" + DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS").format(LocalDateTime.now()) + ".png";
+            Path target = dir.resolve(filename);
+            File screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+            Files.copy(screenshot.toPath(), target);
+            FilePermissions.restrictToOwner(target);
+            logger.error("Saved failure screenshot: {}", target);
+        } catch (Exception e) {
+            logger.warn("Could not capture failure screenshot", e);
         }
     }
 

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -284,15 +284,27 @@ public class SwingMain extends JFrame {
 
         add(centerPanel, BorderLayout.CENTER);
 
-        JPanel statusPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        // BorderLayout, not FlowLayout: a long status message (batch/grouped-login progress
+        // text in particular, e.g. "Logging in once for N profiles sharing ...'s identity
+        // provider: ...") must never be able to wrap the progress bar/cancel button onto a
+        // second row FlowLayout would've had to invent — the fixed-size window (see
+        // setMinimumSize below) never grows to show that second row, silently pushing the
+        // cancel button out of visibility while a batch is actually running. Anchoring the
+        // progress bar/cancel button to EAST keeps them always visible; the CENTER label just
+        // clips instead, with the full text available via tooltip (see the propertyChange
+        // listener below) rather than needing every statusLabel.setText(...) call site updated.
+        JPanel statusPanel = new JPanel(new BorderLayout(8, 0));
         statusPanel.setBorder(BorderFactory.createLoweredBevelBorder());
         statusLabel = new JLabel("Ready");
-        statusPanel.add(statusLabel);
+        statusLabel.addPropertyChangeListener("text", e -> statusLabel.setToolTipText((String) e.getNewValue()));
+        statusPanel.add(statusLabel, BorderLayout.CENTER);
+
+        JPanel statusEastPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 4, 0));
         loginProgressBar = new JProgressBar();
         loginProgressBar.setPreferredSize(new Dimension(120, 16));
         loginProgressBar.setIndeterminate(true);
         loginProgressBar.setVisible(false);
-        statusPanel.add(loginProgressBar);
+        statusEastPanel.add(loginProgressBar);
         // Only shown while a batch refresh is actually running (see
         // refreshExpiringOrExpiredProfiles()), so cancelling stays a single visible click away
         // in the moment it matters without giving the batch action a permanent seat on the
@@ -300,7 +312,9 @@ public class SwingMain extends JFrame {
         batchCancelButton = new JButton("Cancel Batch Refresh");
         batchCancelButton.addActionListener(e -> cancelCredentialRequest());
         batchCancelButton.setVisible(false);
-        statusPanel.add(batchCancelButton);
+        statusEastPanel.add(batchCancelButton);
+        statusPanel.add(statusEastPanel, BorderLayout.EAST);
+
         add(statusPanel, BorderLayout.SOUTH);
 
         pack();


### PR DESCRIPTION
## Summary

**#134 — Capture failure diagnostics instead of guessing further**
- The 30s→60s login-wait bump (#132) was a plausible but unproven mitigation — it assumed "the right page loaded slowly," but a failure could equally mean Selenium landed on an *unexpected* page (device-trust check, bot-check on a fresh headless fingerprint, a silent-auth redirect hop) whose title never matches what `performLogin()` is waiting for, regardless of timeout length.
- `BrowserLoginHandler` now logs the page's URL/title and saves a screenshot on failure — the same capture-on-failure technique the sibling Python app's `ScreenshotRecorder` uses (thanks for the pointer) — to `~/.aws/login-failure-screenshots/`, with the same owner-only file permissions as the credentials file.
- Verified live against a real page (not a synthetic stub): the saved screenshot shows actual rendered content, confirming the mechanism works correctly in headless mode — Selenium's screenshot goes through the browser's own CDP rendering, unlike `java.awt.Robot` elsewhere in this app (which is genuinely broken in this sandboxed environment).
- README's Security section now documents this, consistent with how the rest of that section explains hardening/handling reasoning rather than just what the code does.

**#135 — Fix status bar layout pushing the Cancel button off-screen**
- Reported during UAT with a screenshot: a long batch-progress status message (`FlowLayout`) wrapped the progress bar/Cancel button onto a second row the fixed-size window never grows to show, making Cancel inaccessible exactly when a batch was running and cancelling it mattered.
- Restructured to `BorderLayout`: the label (CENTER) clips instead of wrapping when too long — standard Swing behavior for a space-constrained region — while the progress bar/Cancel button (grouped, EAST) are always positioned and never pushed off.
- Added a `PropertyChangeListener` on the label's "text" property to keep its tooltip in sync automatically, so the full message is still available on hover without touching the ~20 existing `statusLabel.setText(...)` call sites scattered through the file.

## Test plan
- [x] `mvn test` — full suite passes.
- [x] #134 verified live: a real login failure against `https://example.com/` (title never matches the configured `logintitle`) produced both the expected `"Page state at failure — URL: https://example.com/, Title: Example Domain"` log line and a 16.8KB PNG at `~/.aws/login-failure-screenshots/`, `rw-------` permissions confirmed, and the image itself shows the actual "Example Domain" page content.
- [x] #135 verified live via a reflection-driven harness: with an intentionally long status message and the Cancel button forced visible, its screen bounds are fully contained within the window's screen bounds, and its tooltip matches the full un-clipped text.
- [x] Patch version bumped 1.3.11 → 1.3.12 per this repo's `ship-issue` convention.