### PR TITLE
Bump safe-list dependency and plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.12</version>
+    <version>1.3.13</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>
@@ -25,21 +25,21 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.44.0</version>
+            <version>4.46.0</version>
         </dependency>
 
         <!-- AWS SDK -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
-            <version>2.49.3</version>
+            <version>2.50.2</version>
         </dependency>
 
         <!-- XML Processing -->
         <dependency>
             <groupId>org.apache.santuario</groupId>
             <artifactId>xmlsec</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.4</version>
         </dependency>
 
         <!-- INI Config Parser -->
@@ -58,47 +58,47 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.36</version>
+            <version>1.6.1</version>
         </dependency>
 
         <!-- Utilities -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
+            <version>3.20.0</version>
         </dependency>
 
         <!-- Base64 encoding -->
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.17.1</version>
+            <version>1.22.1</version>
         </dependency>
 
         <!-- SQLite JDBC Driver -->
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.46.1.0</version>
+            <version>3.53.2.1</version>
         </dependency>
 
         <!-- FlatLaf - Modern Look and Feel with themes -->
         <dependency>
             <groupId>com.formdev</groupId>
             <artifactId>flatlaf</artifactId>
-            <version>3.4.1</version>
+            <version>3.7.2</version>
         </dependency>
         <!-- FlatLaf IntelliJ Themes (includes GitHub Dark) -->
         <dependency>
             <groupId>com.formdev</groupId>
             <artifactId>flatlaf-intellij-themes</artifactId>
-            <version>3.4.1</version>
+            <version>3.7.2</version>
         </dependency>
         <!-- FlatLaf Extras (FlatAnimatedLafChange for smooth theme-switch transitions) -->
         <dependency>
             <groupId>com.formdev</groupId>
             <artifactId>flatlaf-extras</artifactId>
-            <version>3.4.1</version>
+            <version>3.7.2</version>
         </dependency>
 
         <!-- Testing -->
@@ -111,13 +111,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.15.2</version>
+            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.15.2</version>
+            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -144,7 +144,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>24</source>
                     <target>24</target>
@@ -161,7 +161,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/com/ourgiant/saml/ThemeManager.java
+++ b/src/main/java/com/ourgiant/saml/ThemeManager.java
@@ -7,8 +7,8 @@ import com.formdev.flatlaf.extras.FlatAnimatedLafChange;
 import com.formdev.flatlaf.intellijthemes.FlatArcDarkOrangeIJTheme;
 import com.formdev.flatlaf.intellijthemes.FlatOneDarkIJTheme;
 import com.formdev.flatlaf.intellijthemes.FlatSolarizedDarkIJTheme;
-import com.formdev.flatlaf.intellijthemes.materialthemeuilite.FlatGitHubDarkIJTheme;
-import com.formdev.flatlaf.intellijthemes.materialthemeuilite.FlatGitHubIJTheme;
+import com.formdev.flatlaf.intellijthemes.materialthemeuilite.FlatMTGitHubDarkIJTheme;
+import com.formdev.flatlaf.intellijthemes.materialthemeuilite.FlatMTGitHubIJTheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,8 +35,8 @@ public class ThemeManager {
 
         // FlatLaf themes
         AVAILABLE_THEMES.put("Flat Light", new ThemeInfo(FlatLightLaf.class.getName(), true));
-        AVAILABLE_THEMES.put("GitHub Light", new ThemeInfo(FlatGitHubIJTheme.class.getName(), true));
-        AVAILABLE_THEMES.put("GitHub Dark", new ThemeInfo(FlatGitHubDarkIJTheme.class.getName(), true));
+        AVAILABLE_THEMES.put("GitHub Light", new ThemeInfo(FlatMTGitHubIJTheme.class.getName(), true));
+        AVAILABLE_THEMES.put("GitHub Dark", new ThemeInfo(FlatMTGitHubDarkIJTheme.class.getName(), true));
 
         // Additional dark theme candidates — higher-contrast alternatives to GitHub Dark
         AVAILABLE_THEMES.put("Flat Dark", new ThemeInfo(FlatDarkLaf.class.getName(), true));


### PR DESCRIPTION
## Summary
- Fixes #137, fixes #131
- Bumps the safe (patch/minor, no breaking API) dependency and plugin list end-to-end: `selenium-java` 4.44.0->4.46.0, `flatlaf`/`flatlaf-extras`/`flatlaf-intellij-themes` 3.4.1->3.7.2, `commons-codec` 1.17.1->1.22.1, `commons-lang3` 3.18.0->3.20.0, `xmlsec` 4.0.2->4.0.4, `mockito-core`/`mockito-junit-jupiter` 5.15.2->5.23.0 (test scope), `sqlite-jdbc` 3.46.1.0->3.53.2.1, `software.amazon.awssdk:sts` 2.49.3->2.50.2, `logback-classic` 1.5.36->1.6.1, `maven-compiler-plugin` 3.13.0->3.15.0, `maven-shade-plugin` 3.6.0->3.6.2.
- **Not** touched: `junit-jupiter` (5.11.4->6.1.2 is a major version with breaking API changes — separate pass) and `slf4j-api` (2.1.0-alpha1 is a pre-release — staying on the 2.0.x stable line).
- The FlatLaf 3.7.2 bump renamed `FlatGitHubIJTheme`/`FlatGitHubDarkIJTheme` to `FlatMTGitHubIJTheme`/`FlatMTGitHubDarkIJTheme` in `com.formdev.flatlaf.intellijthemes.materialthemeuilite`. `ThemeManager.java`'s imports and references are updated to match — caught by a `mvn clean package` after a non-clean build initially masked it with stale bytecode.
- On #131 specifically: 4.46.0 is genuinely the latest `selenium-java` release on Maven Central, and its bundled CDP definitions only go up to CDP 150 — Chrome is already at 151. The warning narrows (148->150 fallback) but isn't fully silenced; that's upstream Selenium lag behind Chrome's release cadence, not something fixable from this side right now.

## Test plan
- [x] `mvn clean test` passes in the build container
- [x] `mvn clean package -DskipTests` builds the uber-jar cleanly
- [x] Launched the real app UI (`DISPLAY=:1`, isolated fake `$HOME`) — starts, applies default theme, no exceptions
- [x] Directly exercised all four FlatLaf-backed themes including the two renamed classes (`GitHub Light`, `GitHub Dark`, `Flat Dark`, `Flat Light`) — all apply successfully
- [x] Verified via a standalone ChromeDriver harness that the Selenium bump still triggers the CDP warning (narrowed from CDP 148 to CDP 150 fallback), confirming #131 is upstream-blocked rather than something we're missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)