### PR TITLE
Bump to 1.4.0 for this release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.3.13</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>


### PR DESCRIPTION
## Summary
- Fixes #139
- Version-only change: `pom.xml` 1.3.13 -> 1.4.0
- Since v1.3.0, everything shipped as patch bumps under the per-issue convention (deliberately patch-only per PR), but the accumulated content — batch refresh overhaul, shared SAML assertion reuse, pin/reorder profiles, unify profile selection, expiring-soon status, filtering — is real new functionality, not just fixes. That's a minor-version call that belongs at release-cut time, and got missed on the first pass (published as v1.3.13, then deleted since nothing had downloaded it yet).

## Test plan
- [x] `mvn help:evaluate -Dexpression=project.version` confirms 1.4.0
- No code changes, so no UI verification needed beyond the version-string check

🤖 Generated with [Claude Code](https://claude.com/claude-code)