### PR TITLE
Switch FILE appender to rolling logs under user home

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,8 +6,12 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>aws-saml-ui.log</file>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${user.home}/.aws-idp-saml-ui/logs/app.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${user.home}/.aws-idp-saml-ui/logs/app.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
## Summary
- Fixes #143: replaces the plain `FileAppender` writing to a relative `aws-saml-ui.log` (unbounded, wherever the app happened to be launched from) with a `RollingFileAppender` writing to `${user.home}/.aws-idp-saml-ui/logs/app.log`, using a 7-day `TimeBasedRollingPolicy` — matching the pattern doc-scrubber and kiro-control-panel converged on.
- Deleted the stray `aws-saml-ui.log` at the repo root (already gitignored, untracked).
- Bumped patch version 1.4.0 → 1.4.1.

## Test plan
- [x] `mvn test` passes
- [x] `mvn package -DskipTests` succeeds
- [x] Ran the built jar with an isolated `-Duser.home` and confirmed `app.log` is created at `${user.home}/.aws-idp-saml-ui/logs/app.log`