### PR TITLE
Make silent startup update notice non-modal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -387,9 +387,16 @@ public class SwingMain extends JFrame {
      * @param knownNewerRelease if non-null (tagName-or-version, releaseUrl), an already-confirmed newer
      *                          release to render immediately instead of performing a live GitHub check —
      *                          used when the silent startup check already found and confirmed an update.
+     *                          That silent path also makes the dialog non-modal, so an update found in
+     *                          the background never blocks the main window; Help > About (a deliberate
+     *                          click) stays modal, the normal expectation for that kind of dialog.
      */
     private void showAboutDialog(String[] knownNewerRelease) {
         final String currentVersion = resolveCurrentVersion();
+        final boolean modal = knownNewerRelease == null;
+
+        JDialog dialog = new JDialog(this, "About AWS IDP SAML UI", modal);
+        dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
 
         JPanel panel = new JPanel();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -421,6 +428,12 @@ public class SwingMain extends JFrame {
         panel.add(copyrightLabel);
         panel.add(Box.createVerticalStrut(8));
         panel.add(updateLabel);
+        panel.add(Box.createVerticalStrut(12));
+
+        JButton closeButton = new JButton("Close");
+        closeButton.setAlignmentX(Component.CENTER_ALIGNMENT);
+        closeButton.addActionListener(e -> dialog.dispose());
+        panel.add(closeButton);
 
         if (knownNewerRelease != null) {
             applyUpdateAvailableLabel(updateLabel, knownNewerRelease[0], knownNewerRelease[1]);
@@ -459,7 +472,11 @@ public class SwingMain extends JFrame {
             versionChecker.execute();
         }
 
-        JOptionPane.showMessageDialog(this, panel, "About AWS IDP SAML UI", JOptionPane.PLAIN_MESSAGE);
+        dialog.getContentPane().add(panel);
+        dialog.getRootPane().setDefaultButton(closeButton);
+        dialog.pack();
+        dialog.setLocationRelativeTo(this);
+        dialog.setVisible(true);
     }
 
     private void applyUpdateAvailableLabel(JLabel updateLabel, String latestVersion, String releaseUrl) {


### PR DESCRIPTION
## Summary
- Fixes #142: `showAboutDialog()` always used `JOptionPane.showMessageDialog`, which is unavoidably modal — this meant the silent startup update check also forced a blocking popup once it resolved, contradicting its "silent" intent.
- Reworked it to build a plain `JDialog` whose modality is set per invocation: modal for the manual Help > About click, non-modal when invoked with an already-known newer release (the silent startup path) — matching the dual-mode pattern kiro-control-panel/doc-scrubber's `AboutDialog` converged on.
- Bumped patch version.

## Test plan
- [x] `mvn test` passes
- [x] `mvn package -DskipTests` succeeds
- [x] Live-launched the app (isolated `-Duser.home`) and drove `showAboutDialog` via reflection:
  - silent-path call (non-null known release) returns immediately and opens a **non-modal** dialog; main window stays enabled/interactive with it open
  - manual Help > About call still opens a **modal** dialog, unchanged behavior