### PR TITLE
Remove hardcoded --no-sandbox Chrome flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
+++ b/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
@@ -197,7 +197,6 @@ public class SamlAuthenticator {
         if (!showBrowser) {
             options.addArguments("--headless");
         }
-        options.addArguments("--no-sandbox");
         options.addArguments("--disable-dev-shm-usage");
 
         // Set webdriver.chrome.driver if not set


### PR DESCRIPTION
## Summary
- Fixes #151: `createChromeDriver` unconditionally added `--no-sandbox`, disabling Chrome's OS-level security sandbox. That flag exists for Docker/CI environments without a working user-namespace sandbox — not appropriate for a desktop app running as the logged-in user.
- Bumped patch version to 1.4.3 per convention.

## Test plan
- [x] `mvn test` passes in container
- [x] `mvn package -DskipTests` builds cleanly
- [x] No UI or dependency-version changes, so no live UI verification needed per the ship-issue skill's criteria