### PR TITLE
Remove dead manual chromedriver/geckodriver lookup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.3</version>
+    <version>1.4.4</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
+++ b/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
@@ -14,11 +14,6 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleWithSamlResponse;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
-import java.nio.file.Files;
-import java.io.File;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.CancellationException;
 import java.util.function.Consumer;
 
@@ -199,14 +194,6 @@ public class SamlAuthenticator {
         }
         options.addArguments("--disable-dev-shm-usage");
 
-        // Set webdriver.chrome.driver if not set
-        if (System.getProperty("webdriver.chrome.driver") == null) {
-            String driverPath = findBrowserDriver("chromedriver.exe");
-            if (driverPath != null) {
-                System.setProperty("webdriver.chrome.driver", driverPath);
-            }
-        }
-
         return new ChromeDriver(options);
     }
 
@@ -217,65 +204,7 @@ public class SamlAuthenticator {
         }
         System.setProperty("webdriver.manager.stats", "false");
 
-        // Set webdriver.gecko.driver if not set
-        if (System.getProperty("webdriver.gecko.driver") == null) {
-            String driverPath = findBrowserDriver("geckodriver.exe");
-            if (driverPath != null) {
-                System.setProperty("webdriver.gecko.driver", driverPath);
-            }
-        }
-
         return new FirefoxDriver(options);
-    }
-
-    /**
-     * Find browser driver in common locations
-     */
-    private String findBrowserDriver(String driverName) {
-        // Check current directory
-        Path currentDir = Paths.get(".");
-        Path driverPath = currentDir.resolve("drivers").resolve(driverName);
-        if (Files.exists(driverPath)) {
-            return driverPath.toAbsolutePath().toString();
-        }
-
-        // Check drivers directory relative to executable (works in packaged app-image)
-        Path executableDir;
-        try {
-            executableDir = Path.of(ProcessHandle.current()
-                .info()
-                .command()
-                .orElseThrow())
-                .getParent();
-        } catch (Exception e) {
-            executableDir = null;
-        }
-
-        if (executableDir != null) {
-            driverPath = executableDir.resolve("drivers").resolve(driverName);
-            if (Files.exists(driverPath)) {
-                return driverPath.toAbsolutePath().toString();
-            }
-        }
-
-        // Check system PATH
-        String pathEnv = System.getenv("PATH");
-        if (pathEnv != null) {
-            for (String dir : pathEnv.split(File.pathSeparator)) {
-                if (dir.startsWith("$") || dir.startsWith("%")) continue;
-                try {
-                    Path candidate = Paths.get(dir, driverName);
-                    if (Files.exists(candidate)) {
-                        return candidate.toAbsolutePath().toString();
-                    }
-                } catch (InvalidPathException e) {
-                    logger.warn("Skipping invalid PATH entry: {}", dir);
-                }
-            }
-        }
-
-        logger.warn("Browser driver not found: {}", driverName);
-        return null;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Fixes #152: `findBrowserDriver` searched for `chromedriver.exe`/`geckodriver.exe` (hardcoded `.exe` suffix at both call sites) in a local `drivers/` folder, next to the packaged executable, and on `PATH`. This never matched on Linux/macOS (no `.exe` suffix there) and never matched anywhere since no `drivers/` folder is bundled in packaging. Selenium Manager (Selenium 4.6+, this project is on 4.46.0) already resolves drivers automatically when the `webdriver.*.driver` system properties are left unset — which is what was actually happening at runtime.
- Removed the dead method and its call sites, plus the now-unused `Files`/`Path`/`Paths`/`File`/`InvalidPathException` imports.
- Bumped patch version to 1.4.4 per convention.

## Test plan
- [x] `mvn test` passes in container
- [x] `mvn package -DskipTests` builds cleanly
- [x] `grep` confirms no remaining references to the removed method/properties anywhere in `src/`