### PR TITLE
Use a record for SamlRole; dedupe profile/global fallback lookups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.4</version>
+    <version>1.4.5</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/ConfigManager.java
+++ b/src/main/java/com/ourgiant/saml/ConfigManager.java
@@ -95,116 +95,64 @@ public class ConfigManager {
     }
 
     /**
+     * Looks up a key on the named profile, falling back to the same key on the global
+     * section when the profile doesn't set it (or doesn't exist). Every profile-scoped
+     * setting below follows this same precedence.
+     */
+    private String getWithGlobalFallback(String profileName, String key) {
+        Profile.Section profile = getProfile(profileName);
+        if (profile != null) {
+            String value = profile.get(key);
+            if (value != null) {
+                return value;
+            }
+        }
+
+        Profile.Section global = getGlobalConfig();
+        return global != null ? global.get(key) : null;
+    }
+
+    /**
      * Get AWS region for a profile
      */
     public String getAwsRegion(String profileName) {
-        Profile.Section profile = getProfile(profileName);
-        if (profile != null) {
-            String region = profile.get("awsregion");
-            if (region != null) {
-                return region;
-            }
-        }
-
-        // Fall back to global config
-        Profile.Section global = getGlobalConfig();
-        if (global != null) {
-            String region = global.get("awsregion");
-            if (region != null) {
-                return region;
-            }
-            return "us-east-1";
-        }
-
-        return "us-east-1";
+        String region = getWithGlobalFallback(profileName, "awsregion");
+        return region != null ? region : "us-east-1";
     }
 
     /**
      * Get account number for a profile
      */
     public String getAccountNumber(String profileName) {
-        Profile.Section profile = getProfile(profileName);
-        if (profile != null) {
-            String accountNumber = profile.get("accountnumber");
-            if (accountNumber != null) {
-                return accountNumber;
-            }
-        }
-
-        // Fall back to global config
-        Profile.Section global = getGlobalConfig();
-        if (global != null) {
-            return global.get("accountnumber");
-        }
-
-        return null;
+        return getWithGlobalFallback(profileName, "accountnumber");
     }
 
     /**
      * Get IAM role for a profile
      */
     public String getIamRole(String profileName) {
-        Profile.Section profile = getProfile(profileName);
-        if (profile != null) {
-            String iamRole = profile.get("iamrole");
-            if (iamRole != null) {
-                return iamRole;
-            }
-        }
-
-        // Fall back to global config
-        Profile.Section global = getGlobalConfig();
-        if (global != null) {
-            return global.get("iamrole");
-        }
-
-        return null;
+        return getWithGlobalFallback(profileName, "iamrole");
     }
 
     /**
      * Get SAML provider for a profile
      */
     public String getSamlProvider(String profileName) {
-        Profile.Section profile = getProfile(profileName);
-        if (profile != null) {
-            String samlProvider = profile.get("samlprovider");
-            if (samlProvider != null) {
-                return samlProvider;
-            }
-        }
-
-        // Fall back to global config
-        Profile.Section global = getGlobalConfig();
-        if (global != null) {
-            return global.get("samlprovider");
-        }
-
-        return null;
+        return getWithGlobalFallback(profileName, "samlprovider");
     }
 
     /**
      * Get username for a profile
      */
     public String getUsername(String profileName) {
-        Profile.Section profile = getProfile(profileName);
-        if (profile != null) {
-            String username = profile.get("username");
-            if (username != null) {
-                return username;
-            }
+        String username = getWithGlobalFallback(profileName, "username");
+        if (username != null) {
+            return username;
         }
 
-        // Fall back to global config - also check lowercase variant
+        // Legacy capitalized variant, global-only
         Profile.Section global = getGlobalConfig();
-        if (global != null) {
-            String username = global.get("username");
-            if (username != null) {
-                return username;
-            }
-            return global.get("User");
-        }
-
-        return null;
+        return global != null ? global.get("User") : null;
     }
 
     /**

--- a/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
+++ b/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
@@ -212,8 +212,8 @@ public class SamlAuthenticator {
      */
     private String findMatchingRole(java.util.List<SamlRole> roles, String accountNumber, String iamRole) {
         for (SamlRole role : roles) {
-            if (role.getAccountNumber().equals(accountNumber) && role.getRoleName().equals(iamRole)) {
-                return role.getRoleArn();
+            if (role.accountNumber().equals(accountNumber) && role.roleName().equals(iamRole)) {
+                return role.roleArn();
             }
         }
         throw new RuntimeException("Matching role not found in SAML response: " + accountNumber + "/" + iamRole);

--- a/src/main/java/com/ourgiant/saml/SamlRole.java
+++ b/src/main/java/com/ourgiant/saml/SamlRole.java
@@ -3,32 +3,22 @@ package com.ourgiant.saml;
 /**
  * Represents a SAML role parsed from the assertion
  */
-public class SamlRole {
-    private final String roleArn;
-    private final String principalArn;
-    private final String accountNumber;
-    private final String roleName;
+public record SamlRole(String roleArn, String principalArn, String accountNumber, String roleName) {
 
     public SamlRole(String roleArn, String principalArn) {
-        this.roleArn = roleArn;
-        this.principalArn = principalArn;
-
-        // Parse account number and role name from ARN
-        // Format: arn:aws:iam::123456789012:role/RoleName
-        String[] arnParts = roleArn.split(":");
-        if (arnParts.length >= 6) {
-            this.accountNumber = arnParts[4];
-            this.roleName = arnParts[5].substring(5); // Remove "role/" prefix
-        } else {
-            this.accountNumber = "unknown";
-            this.roleName = "unknown";
-        }
+        this(roleArn, principalArn, parseAccountNumber(roleArn), parseRoleName(roleArn));
     }
 
-    public String getRoleArn() { return roleArn; }
-    public String getPrincipalArn() { return principalArn; }
-    public String getAccountNumber() { return accountNumber; }
-    public String getRoleName() { return roleName; }
+    // Format: arn:aws:iam::123456789012:role/RoleName
+    private static String parseAccountNumber(String roleArn) {
+        String[] arnParts = roleArn.split(":");
+        return arnParts.length >= 6 ? arnParts[4] : "unknown";
+    }
+
+    private static String parseRoleName(String roleArn) {
+        String[] arnParts = roleArn.split(":");
+        return arnParts.length >= 6 ? arnParts[5].substring(5) : "unknown"; // Remove "role/" prefix
+    }
 
     @Override
     public String toString() {

--- a/src/test/java/com/ourgiant/saml/ConfigManagerTest.java
+++ b/src/test/java/com/ourgiant/saml/ConfigManagerTest.java
@@ -107,4 +107,59 @@ class ConfigManagerTest {
         assertFalse(written.contains("\\:"), "created samlsts should not contain escaped colons:\n" + written);
         assertTrue(written.contains("https://example.okta.com/app/example/sso/saml"));
     }
+
+    @Test
+    void profileScopedGetters_preferProfileOverGlobal() throws Exception {
+        writeSamlsts("""
+                [global]
+                accountnumber = 000000000000
+                iamrole = GlobalRole
+                samlprovider = Fed-Global
+
+                [my-profile]
+                accountnumber = 111111111111
+                iamrole = ProfileRole
+                samlprovider = Fed-Profile
+                """);
+
+        configManager = new ConfigManager();
+
+        assertEquals("111111111111", configManager.getAccountNumber("my-profile"));
+        assertEquals("ProfileRole", configManager.getIamRole("my-profile"));
+        assertEquals("Fed-Profile", configManager.getSamlProvider("my-profile"));
+    }
+
+    @Test
+    void profileScopedGetters_fallBackToGlobalWhenProfileOmitsKey() throws Exception {
+        writeSamlsts("""
+                [global]
+                accountnumber = 000000000000
+                iamrole = GlobalRole
+                samlprovider = Fed-Global
+                awsregion = us-west-2
+
+                [my-profile]
+                """);
+
+        configManager = new ConfigManager();
+
+        assertEquals("000000000000", configManager.getAccountNumber("my-profile"));
+        assertEquals("GlobalRole", configManager.getIamRole("my-profile"));
+        assertEquals("Fed-Global", configManager.getSamlProvider("my-profile"));
+        assertEquals("us-west-2", configManager.getAwsRegion("my-profile"));
+    }
+
+    @Test
+    void getAwsRegion_defaultsToUsEast1WhenUnset() throws Exception {
+        writeSamlsts("""
+                [global]
+                idp_entry_url = https://example.okta.com/app/example/sso/saml
+
+                [my-profile]
+                """);
+
+        configManager = new ConfigManager();
+
+        assertEquals("us-east-1", configManager.getAwsRegion("my-profile"));
+    }
 }

--- a/src/test/java/com/ourgiant/saml/SamlParserTest.java
+++ b/src/test/java/com/ourgiant/saml/SamlParserTest.java
@@ -27,10 +27,10 @@ class SamlParserTest {
         List<SamlRole> roles = parser.parseRolesFromSaml(encode(saml));
 
         assertEquals(2, roles.size());
-        assertEquals("123456789012", roles.get(0).getAccountNumber());
-        assertEquals("AdminRole", roles.get(0).getRoleName());
-        assertEquals("987654321098", roles.get(1).getAccountNumber());
-        assertEquals("ReadOnlyRole", roles.get(1).getRoleName());
+        assertEquals("123456789012", roles.get(0).accountNumber());
+        assertEquals("AdminRole", roles.get(0).roleName());
+        assertEquals("987654321098", roles.get(1).accountNumber());
+        assertEquals("ReadOnlyRole", roles.get(1).roleName());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes #154:
  - `SamlRole` converted to a record — it was already a plain immutable data holder with a manual constructor/getters/`toString()`. The account-number/role-name-from-ARN parsing is preserved via a non-canonical constructor delegating to the canonical one. Call sites updated to the record's canonical accessors (`roleArn()`, `accountNumber()`, etc.) instead of `getX()`.
  - `ConfigManager`'s profile-getter methods (`getAwsRegion`, `getAccountNumber`, `getIamRole`, `getSamlProvider`, `getUsername`) all repeated the same "check the profile section, fall back to the global section" null-checking shape. Extracted into a single `getWithGlobalFallback` helper; each getter's own extra default/fallback (`getAwsRegion`'s `"us-east-1"`, `getUsername`'s legacy `"User"` global fallback) is layered on top, unchanged.
- Scoped down from the issue's other suggestion (dedicated `ProfileConfig`/`ProviderConfig` record types wrapping `Profile.Section`): that would mean changing `Profile.Section`'s type everywhere it's consumed (`ProfileEditDialog`, `CredentialManager`, etc.), which is a much larger, riskier change for the same boilerplate-reduction benefit the helper method already gets here. Left as a possible future follow-up if it turns out to be worth it.
- Bumped patch version to 1.4.5 per convention.

## Test plan
- [x] `mvn test` passes in container (50 tests, incl. 3 new `ConfigManagerTest` cases covering profile-vs-global precedence, previously untested)
- [x] `mvn package -DskipTests` builds cleanly
- [x] No UI or dependency-version changes, so no live UI verification needed per the ship-issue skill's criteria