### PR TITLE
Show a countdown while waiting for MFA/redirect confirmation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.5</version>
+    <version>1.4.6</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/BrowserLoginHandler.java
@@ -26,6 +26,8 @@ import java.util.function.Function;
 public class BrowserLoginHandler {
     private static final Logger logger = LoggerFactory.getLogger(BrowserLoginHandler.class);
 
+    private static final Duration MAIN_WAIT_TIMEOUT = Duration.ofSeconds(60);
+
     private final WebDriver driver;
     private final WebDriverWait wait;
     private final boolean useOktaFastPass;
@@ -47,7 +49,7 @@ public class BrowserLoginHandler {
         // performLogin()/handleOktaLogin()/waitForSamlResponse() - the various short "probe"
         // waits elsewhere in this class (3s/5s/10s, used to detect *optional* page states) are
         // deliberately short by design and untouched here.
-        this.wait = new WebDriverWait(driver, Duration.ofSeconds(60));
+        this.wait = new WebDriverWait(driver, MAIN_WAIT_TIMEOUT);
         this.useOktaFastPass = useOktaFastPass;
         this.passwordManager = passwordManager;
         this.showBrowser = showBrowser;
@@ -66,6 +68,23 @@ public class BrowserLoginHandler {
             if (cancelled.getAsBoolean()) {
                 throw new CancellationException("Login cancelled");
             }
+            return condition.apply(driver);
+        });
+    }
+
+    /**
+     * Same as {@link #until}, but reports a countdown against {@code timeout} on every poll so a
+     * long, otherwise-silent wait (MFA approval) doesn't look indistinguishable from a hung app.
+     */
+    private <V> V untilWithCountdown(WebDriverWait waitInstance, Function<WebDriver, V> condition,
+                                      Duration timeout, String waitingMessage) {
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        return waitInstance.until(driver -> {
+            if (cancelled.getAsBoolean()) {
+                throw new CancellationException("Login cancelled");
+            }
+            long remainingSeconds = Math.max(0, (deadline - System.currentTimeMillis()) / 1000);
+            statusCallback.accept(waitingMessage + " (" + remainingSeconds + "s remaining)...");
             return condition.apply(driver);
         });
     }
@@ -380,8 +399,8 @@ public class BrowserLoginHandler {
     private String waitForSamlResponse() throws Exception {
         logger.info("Waiting for SAML response...");
 
-        statusCallback.accept("Waiting for redirect to AWS sign-in page...");
-        until(wait, ExpectedConditions.urlContains("signin.aws.amazon.com"));
+        untilWithCountdown(wait, ExpectedConditions.urlContains("signin.aws.amazon.com"),
+                MAIN_WAIT_TIMEOUT, "Waiting for redirect to AWS sign-in page");
 
         statusCallback.accept("Capturing SAML response...");
 


### PR DESCRIPTION
## Summary
- Fixes #155: once the app sends the Okta MFA push and shows "check your device," the wait for the AWS SAML redirect (up to 60s) was silent — a generic indeterminate progress bar was already visible in the status bar the whole time, but no MFA-specific feedback and no sense of how much time was left before the app would time out.
- Added `untilWithCountdown`, a variant of the existing `until()` poll wrapper that reports remaining seconds against the wait's timeout on every poll via the existing `statusCallback`. Applied it to the `waitForSamlResponse` redirect wait, which covers both the MFA-push and FastPass paths.
- Extracted the wait's `60`-second timeout into a named `MAIN_WAIT_TIMEOUT` constant shared by the `WebDriverWait` and the new countdown, so they can't drift apart if the timeout is ever tuned.

## Test plan
- [x] `mvn test` passes in container
- [x] `mvn package -DskipTests` builds cleanly
- [ ] Live verification of the actual countdown text during a real MFA wait not done — it requires a real Okta session/credentials this environment doesn't have. The change is isolated to `BrowserLoginHandler` (not a GUI class); no window/dialog/menu was touched and no `pom.xml` dependency version changed, so this falls outside the cases the ship-issue skill flags as requiring a live UI check, but flagging the gap explicitly rather than claiming it was verified.