### PR TITLE
Inject ConfigManager/CredentialManager/PasswordManager into SamlAuthenticator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
+++ b/src/main/java/com/ourgiant/saml/SamlAuthenticator.java
@@ -28,10 +28,11 @@ public class SamlAuthenticator {
     private final PasswordManager passwordManager;
     private volatile boolean cancelled = false;
 
-    public SamlAuthenticator() {
-        this.configManager = new ConfigManager();
-        this.credentialManager = new CredentialManager();
-        this.passwordManager = new PasswordManager(new DatabaseManager());
+    public SamlAuthenticator(ConfigManager configManager, CredentialManager credentialManager,
+                              PasswordManager passwordManager) {
+        this.configManager = configManager;
+        this.credentialManager = credentialManager;
+        this.passwordManager = passwordManager;
     }
 
     // Just sets a flag that BrowserLoginHandler checks between polls of every Selenium wait,
@@ -210,7 +211,7 @@ public class SamlAuthenticator {
     /**
      * Find matching role from SAML response
      */
-    private String findMatchingRole(java.util.List<SamlRole> roles, String accountNumber, String iamRole) {
+    String findMatchingRole(java.util.List<SamlRole> roles, String accountNumber, String iamRole) {
         for (SamlRole role : roles) {
             if (role.accountNumber().equals(accountNumber) && role.roleName().equals(iamRole)) {
                 return role.roleArn();

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -965,7 +965,7 @@ public class SwingMain extends JFrame {
         loginProgressBar.setVisible(true);
         statusLabel.setText("Starting credential request for profile: " + selectedProfile + "...");
 
-        SamlAuthenticator authenticator = new SamlAuthenticator();
+        SamlAuthenticator authenticator = new SamlAuthenticator(configManager, credentialManager, passwordManager);
         activeAuthenticator = authenticator;
 
         // Run credential request in background thread
@@ -1169,7 +1169,7 @@ public class SwingMain extends JFrame {
                             + " (" + representativeProfile + "): ";
                     publish(loginPrefix + "starting...");
 
-                    SamlAuthenticator authenticator = new SamlAuthenticator();
+                    SamlAuthenticator authenticator = new SamlAuthenticator(configManager, credentialManager, passwordManager);
                     activeAuthenticator = authenticator;
                     String assertion;
                     try {

--- a/src/test/java/com/ourgiant/saml/SamlAuthenticatorTest.java
+++ b/src/test/java/com/ourgiant/saml/SamlAuthenticatorTest.java
@@ -1,0 +1,52 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class SamlAuthenticatorTest {
+
+    @Mock
+    private ConfigManager configManager;
+
+    @Mock
+    private CredentialManager credentialManager;
+
+    @Mock
+    private PasswordManager passwordManager;
+
+    private SamlAuthenticator authenticator() {
+        return new SamlAuthenticator(configManager, credentialManager, passwordManager);
+    }
+
+    @Test
+    void findMatchingRole_returnsArnOfMatchingAccountAndRoleName() {
+        List<SamlRole> roles = List.of(
+                new SamlRole("arn:aws:iam::123456789012:role/AdminRole", "arn:aws:iam::123456789012:saml-provider/Okta"),
+                new SamlRole("arn:aws:iam::987654321098:role/ReadOnlyRole", "arn:aws:iam::987654321098:saml-provider/Okta")
+        );
+
+        String roleArn = authenticator().findMatchingRole(roles, "987654321098", "ReadOnlyRole");
+
+        assertEquals("arn:aws:iam::987654321098:role/ReadOnlyRole", roleArn);
+    }
+
+    @Test
+    void findMatchingRole_throwsWhenNoRoleMatchesAccountAndName() {
+        List<SamlRole> roles = List.of(
+                new SamlRole("arn:aws:iam::123456789012:role/AdminRole", "arn:aws:iam::123456789012:saml-provider/Okta")
+        );
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> authenticator().findMatchingRole(roles, "999999999999", "AdminRole"));
+
+        assertEquals("Matching role not found in SAML response: 999999999999/AdminRole", ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #150: `SamlAuthenticator`'s no-arg constructor built its own `ConfigManager`, `CredentialManager`, and `PasswordManager(new DatabaseManager())` — each of those opens its own SQLite connection (`DatabaseManager`'s constructor opens a `Connection` that only `close()` releases) that was never closed. `SwingMain` already creates its own long-lived `configManager`/`credentialManager`/`passwordManager` fields at startup; `SamlAuthenticator` was ignoring them and building fresh, abandoned copies on **every** credential request, and once per identity-provider group in batch refresh.
- `SamlAuthenticator` now takes these three as constructor parameters. Both call sites in `SwingMain` pass its existing shared instances instead.
- `findMatchingRole` made package-private (matching the existing `toXPathLiteral` convention in `BrowserLoginHandlerXPathLiteralTest`) and covered by a new `SamlAuthenticatorTest` using Mockito fakes for the three injected collaborators — the role-matching logic is now unit-testable without a browser, database, or files.

## Test plan
- [x] `mvn test` passes in container — 52 tests, incl. 2 new `SamlAuthenticatorTest` cases
- [x] `mvn package -DskipTests` builds cleanly
- [x] Live UI verification: launched the real `SwingMain` against a fake `$HOME`/`samlsts` via a reflection harness on the real X11 display, confirmed `configManager`/`credentialManager`/`passwordManager` are all non-null on the running window, then clicked "Request Credentials" through to a clean config-validation error ("Incomplete profile configuration for: my-profile") rather than a wiring `NullPointerException` — confirming the new constructor wiring works end-to-end through the real UI