### PR TITLE
Always show pinned profiles regardless of the active filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.8</version>
+    <version>1.4.9</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -830,8 +830,18 @@ public class SwingMain extends JFrame {
                 return allowedStatuses.contains(entry.getStringValue(1));
             }
         });
+        RowFilter<Object, Object> statusAndTextFilter = RowFilter.andFilter(filters);
 
-        tokenStatusRowSorter.setRowFilter(RowFilter.andFilter(filters));
+        // Pinning is meant to keep favorites within easy reach regardless of how the rest of
+        // the list is being filtered (#147), so a pinned profile bypasses both the text and
+        // status filters above rather than being subject to them like any other row.
+        RowFilter<Object, Object> pinnedOrFiltered = new RowFilter<>() {
+            @Override
+            public boolean include(Entry<?, ?> entry) {
+                return pinnedProfileOrder.contains(entry.getStringValue(0)) || statusAndTextFilter.include(entry);
+            }
+        };
+        tokenStatusRowSorter.setRowFilter(pinnedOrFiltered);
     }
 
     private int getStatusOrder(String status) {


### PR DESCRIPTION
## Summary
- Fixes #147: the status-table row filter (text search + Valid/Expired/Unknown checkboxes) applied uniformly to every row, so a pinned profile could still be hidden by it — e.g. unchecking "Unknown" hides a pinned-but-not-yet-authenticated profile along with everything else, defeating the purpose of pinning it for quick access.
- `applyFilters()` now ORs the existing text+status filter with a check against `pinnedProfileOrder`, so a pinned profile stays visible no matter how the rest of the list is filtered.

## A bug the live verification caught
The first version of this fix built and passed `mvn test`/`mvn package` cleanly but crashed the instant the row filter actually ran, with `java.lang.Error: Unresolved compilation problems: Name clash...`. Root cause: assigning the new combined `RowFilter` directly inline into `setRowFilter(...)` let the diamond operator infer its type from that method's lower-bounded wildcard parameter (`RowFilter<DefaultTableModel, Integer>`), and an `include(Entry<?, ?>)` override isn't actually valid against that per JLS override rules — this environment's compiler emits a runtime-throwing stub for it instead of failing the build, so the problem was invisible until the filter ran for real. Fixed by assigning the anonymous class to an explicitly-typed `RowFilter<Object, Object>` local variable first (matching the pattern already used elsewhere in this same method), which forces the correct, valid override. Confirms why this file's changes get a live-UI check rather than stopping at a green `mvn package`.

## Test plan
- [x] `mvn test` passes in container
- [x] `mvn package -DskipTests` builds cleanly
- [x] Live UI verification: 3 profiles, all `UNKNOWN` status. Unchecking "Unknown" hid all 3 (`rows with Unknown unchecked, nothing pinned=0`). Pinning one via `toggleProfilePinned` (same method the context menu's "Pin Profile" item calls) brought it back as the *only* visible row (`rows with Unknown unchecked, profile-b pinned=1`, `visible row 0: profile-b`) — confirming the fix works end-to-end through the real filter/sorter, not just in isolation