### PR TITLE
Add trusted-URL check and SSLHandshakeException handling to the update checker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.9</version>
+    <version>1.4.10</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -461,7 +461,9 @@ public class SwingMain extends JFrame {
                             updateLabel.setText("Could not check for updates");
                         }
                     } catch (Exception e) {
-                        updateLabel.setText("Could not check for updates");
+                        Throwable cause = e.getCause();
+                        updateLabel.setText(cause instanceof UpdateFetchSslException sslEx
+                            ? sslEx.getMessage() : "Could not check for updates");
                         logger.debug("Version check failed", e);
                     }
                     panel.revalidate();
@@ -486,12 +488,27 @@ public class SwingMain extends JFrame {
             @Override
             public void mouseClicked(java.awt.event.MouseEvent e) {
                 try {
-                    Desktop.getDesktop().browse(new java.net.URI(releaseUrl));
+                    java.net.URI uri = new java.net.URI(releaseUrl);
+                    if (!isTrustedReleaseUrl(uri)) {
+                        logger.warn("Refusing to open untrusted release URL: {}", releaseUrl);
+                        return;
+                    }
+                    Desktop.getDesktop().browse(uri);
                 } catch (Exception ex) {
                     logger.warn("Could not open release URL in browser", ex);
                 }
             }
         });
+    }
+
+    /**
+     * Defense in depth, not a response to a live exploit: {@code uri} comes straight from
+     * GitHub's releases API response, so a tampered response (only possible with an existing
+     * TLS MITM position) could otherwise point this at an arbitrary URI/scheme. Restrict to
+     * exactly the host the API is expected to point back to.
+     */
+    static boolean isTrustedReleaseUrl(java.net.URI uri) {
+        return "https".equalsIgnoreCase(uri.getScheme()) && "github.com".equalsIgnoreCase(uri.getHost());
     }
 
     /**
@@ -576,10 +593,21 @@ public class SwingMain extends JFrame {
                     return new String[]{tagName, htmlUrl};
                 }
             }
+        } catch (javax.net.ssl.SSLHandshakeException e) {
+            logger.warn("TLS handshake failed fetching latest release from GitHub (possible TLS-inspecting proxy)", e);
+            throw new UpdateFetchSslException(
+                "Couldn't verify the secure connection (possible corporate network proxy)", e);
         } catch (Exception e) {
             logger.debug("Failed to fetch latest release from GitHub", e);
         }
         return null;
+    }
+
+    /** Lets the update-check UI distinguish "TLS handshake failed" from any other fetch failure. */
+    private static class UpdateFetchSslException extends RuntimeException {
+        UpdateFetchSslException(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 
     static String extractJsonString(String json, String key) {

--- a/src/test/java/com/ourgiant/saml/SwingMainTrustedReleaseUrlTest.java
+++ b/src/test/java/com/ourgiant/saml/SwingMainTrustedReleaseUrlTest.java
@@ -1,0 +1,38 @@
+package com.ourgiant.saml;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SwingMainTrustedReleaseUrlTest {
+
+    @Test
+    void trustsAnHttpsGitHubReleaseUrl() {
+        assertTrue(SwingMain.isTrustedReleaseUrl(
+            URI.create("https://github.com/OurGiant/aws-idp-saml-ui/releases/tag/v1.4.9")));
+    }
+
+    @Test
+    void rejectsNonHttpsScheme() {
+        // Regression-style test: releaseUrl comes straight from the GitHub API response, so a
+        // tampered response (only possible with an existing TLS MITM position) shouldn't be
+        // able to point Desktop.browse() at an arbitrary scheme.
+        assertFalse(SwingMain.isTrustedReleaseUrl(
+            URI.create("file:///etc/passwd")));
+    }
+
+    @Test
+    void rejectsANonGitHubHost() {
+        assertFalse(SwingMain.isTrustedReleaseUrl(
+            URI.create("https://evil.example.com/releases/tag/v1.4.9")));
+    }
+
+    @Test
+    void rejectsAGitHubLookalikeHost() {
+        assertFalse(SwingMain.isTrustedReleaseUrl(
+            URI.create("https://github.com.evil.example.com/releases/tag/v1.4.9")));
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #148: two gaps flagged by the standardization committee's full-skill audit (2026-08-06), both already fixed on every sibling project (kiro-control-panel, doc-scrubber, etc.) but not yet backported here.
- **Trusted-URL check**: `applyUpdateAvailableLabel()`'s click handler called `Desktop.getDesktop().browse(new URI(releaseUrl))` directly on the URL from the GitHub API response, with no host/scheme validation — defense-in-depth against a tampered/MITM'd API response feeding an arbitrary URI into the user's browser. Added `isTrustedReleaseUrl()`, ported verbatim from doc-scrubber's/kiro-control-panel's `AboutDialog`: exactly `https://github.com/...`, rejecting scheme swaps, non-GitHub hosts, and `github.com.*` lookalike subdomains.
- **SSLHandshakeException handling**: `fetchLatestRelease()` caught a blanket `Exception` and returned `null` in every case, so a TLS handshake failure (a real recurring corporate-proxy issue for this team) looked identical to "offline" or "rate-limited." Added a specific `SSLHandshakeException` catch that surfaces "Couldn't verify the secure connection (possible corporate network proxy)" in the About dialog's update-check label, via a small private `UpdateFetchSslException` the version-check `SwingWorker`'s `done()` can distinguish from a generic failure. The silent background check (`checkForUpdatesInBackground()`) is unaffected — its existing catch-all still swallows this the same as any other fetch failure, by design.
- Kept both fixes in place in `SwingMain` rather than factoring out a dedicated `AboutDialog`/`UpdateChecker` pair like the sibling projects — matches the issue's own explicit scoping ("not required to restructure wholesale for this fix").

## Test plan
- [x] `mvn test` passes in container — 57 tests, incl. 4 new `SwingMainTrustedReleaseUrlTest` cases (trusts a real GitHub URL; rejects non-https, non-GitHub host, and GitHub-lookalike-subdomain)
- [x] `mvn package -DskipTests` builds cleanly
- [x] Live UI verification: dispatched a real click event on the update label pointed at a malicious (non-`github.com`) URL and confirmed the log shows `"Refusing to open untrusted release URL: https://evil.example.com/malicious-payload"` — proving the guard actually fires in the wired-up click handler and returns before ever reaching `Desktop.browse()`, without launching a real browser on the shared display
- [ ] The `SSLHandshakeException` path isn't independently live-verified — it requires an actual TLS-intercepting network position to trigger, not reproducible in this environment. It reuses the same catch/message pattern already shipped and working on the sibling projects it was ported from.