### PR TITLE
Force batch refresh to always run headless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.10</version>
+    <version>1.4.11</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/SwingMain.java
@@ -1161,9 +1161,14 @@ public class SwingMain extends JFrame {
         SwingWorker<List<BatchRefreshRunner.Result>, String> worker = new SwingWorker<>() {
             @Override
             protected List<BatchRefreshRunner.Result> doInBackground() {
+                // Always headless (#149): watching N browser windows open one after another
+                // for a multi-profile batch isn't a usable experience the "Show browser"
+                // checkbox was ever designed for - that's a single-profile debugging aid. This
+                // also means batch refresh always gets the shared-login grouping optimization
+                // (see BatchRefreshRunner.run()), which showBrowser=true used to disable too.
                 return batchRefreshRunner.run(
                     targets,
-                    showBrowserCheckBox.isSelected(),
+                    false,
                     () -> credentialRequestCancelledByUser,
                     authenticator -> activeAuthenticator = authenticator,
                     this::publish


### PR DESCRIPTION
## Summary
- Fixes #149: batch refresh (both "Refresh Expiring/Expired" and "Refresh Selected") read `showBrowserCheckBox.isSelected()` the same as the single-profile flow, so checking "Show browser" opened a real, visible browser window per login group during a multi-profile batch run — not what that checkbox was designed for (a single-profile debugging aid), and disruptive across a run touching many profiles. It also disabled `BatchRefreshRunner`'s shared-login grouping optimization, since that only activates when `showBrowser=false`.
- `runBatchRefresh`'s `SwingWorker` now passes a hardcoded `false` to `BatchRefreshRunner.run()` instead of the checkbox's value, so batch refresh is unconditionally headless and always gets the grouping optimization. The checkbox itself is untouched — it still controls the single-profile "Request Credentials" flow exactly as before.

## Test plan
- [x] `mvn test` passes in container — 57 tests
- [x] `mvn package -DskipTests` builds cleanly
- [x] Live UI verification: checked "Show browser," selected a profile, drove "Refresh Selected Profiles..." through its confirm dialog, and inspected the real spawned Chrome process's `/proc/<pid>/cmdline` directly — confirmed both `--headless` and `--ozone-platform=headless` are present in the actual launched process despite the checkbox being checked. (First attempt used `ProcessHandle.info().commandLine()`, which silently truncated the output and gave a false "not headless" reading — worth flagging in case this bites anyone else verifying Selenium-launched processes this way.) Cancelled the run promptly afterward and confirmed 0 descendant processes remained, so no orphaned browser was left on the shared display.