### PR TITLE
Bump to 1.5.0 for this release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.4.12</version>
+    <version>1.5.0</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>


### PR DESCRIPTION
## Summary
- Minor version bump for the 1.5.0 release, per release-day convention (all patch bumps since the last release consolidate into a minor).

## Test plan
- [x] CI (test/build-windows/build-linux/build-macos) passes on this PR