### PR TITLE
Poll for pre-authenticated Okta MFA screen with exponential backoff

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/core/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/core/BrowserLoginHandler.java
@@ -30,6 +30,12 @@ public class BrowserLoginHandler {
 
     private static final Duration MAIN_WAIT_TIMEOUT = Duration.ofSeconds(60);
 
+    private static final String MFA_SCREEN_INDICATOR = "class=\"button select-factor link-button\"";
+    private static final Duration MFA_SCREEN_POLL_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration BACKOFF_INITIAL_DELAY = Duration.ofSeconds(1);
+    private static final Duration BACKOFF_MAX_DELAY = Duration.ofSeconds(4);
+    private static final double BACKOFF_FACTOR = 2.0;
+
     private final WebDriver driver;
     private final WebDriverWait wait;
     private final boolean useOktaFastPass;
@@ -281,11 +287,51 @@ public class BrowserLoginHandler {
         try {
             WebDriverWait shortWait = new WebDriverWait(driver, Duration.ofSeconds(10));
             until(shortWait, ExpectedConditions.presenceOfElementLocated(By.linkText("Back to sign in")));
-            String pageSource = driver.getPageSource();
-            boolean hasMfaIndicator = pageSource.contains("class=\"button select-factor link-button\"");
-            return hasMfaIndicator;
         } catch (TimeoutException e) {
             return false;
+        }
+        return pollPageSourceWithBackoff(MFA_SCREEN_INDICATOR, MFA_SCREEN_POLL_TIMEOUT);
+    }
+
+    /**
+     * Polls the page source for a substring, backing off exponentially between attempts instead of
+     * checking once immediately. Okta's factor-selection markup can render after the "Back to sign
+     * in" link is already present in the DOM — especially on Firefox — so a one-shot check right
+     * after that wait resolves can miss it, while a slow-rendering page still finishes well within
+     * this method's own deadline. Ported from the Python sibling's
+     * {@code SeleniumHelper.poll_page_source_with_backoff} (aws-idp-saml #83).
+     */
+    private boolean pollPageSourceWithBackoff(String needle, Duration maxTotalDuration) {
+        return pollPageSourceWithBackoff(needle, maxTotalDuration, BACKOFF_INITIAL_DELAY, BACKOFF_MAX_DELAY, BACKOFF_FACTOR);
+    }
+
+    /** Package-private so the backoff timing itself can be unit tested with millisecond-scale durations. */
+    boolean pollPageSourceWithBackoff(String needle, Duration maxTotalDuration,
+                                       Duration initialDelay, Duration maxDelay, double backoffFactor) {
+        long deadline = System.currentTimeMillis() + maxTotalDuration.toMillis();
+        long delayMillis = initialDelay.toMillis();
+        int attempt = 0;
+        while (true) {
+            attempt++;
+            if (cancelled.getAsBoolean()) {
+                throw new CancellationException("Login cancelled");
+            }
+            if (driver.getPageSource().contains(needle)) {
+                logger.debug("Found '{}' in page source on attempt {}", needle, attempt);
+                return true;
+            }
+            long remainingMillis = deadline - System.currentTimeMillis();
+            if (remainingMillis <= 0) {
+                logger.info("Timed out waiting for '{}' in page source after {} attempts", needle, attempt);
+                return false;
+            }
+            try {
+                Thread.sleep(Math.min(delayMillis, remainingMillis));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+            delayMillis = Math.min((long) (delayMillis * backoffFactor), maxDelay.toMillis());
         }
     }
 

--- a/src/test/java/com/ourgiant/saml/core/BrowserLoginHandlerBackoffPollTest.java
+++ b/src/test/java/com/ourgiant/saml/core/BrowserLoginHandlerBackoffPollTest.java
@@ -1,0 +1,73 @@
+package com.ourgiant.saml.core;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WebDriver;
+
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BrowserLoginHandlerBackoffPollTest {
+
+    private static final Duration TINY_DELAY = Duration.ofMillis(5);
+
+    private BrowserLoginHandler newHandler(WebDriver driver, java.util.function.BooleanSupplier cancelled) {
+        return new BrowserLoginHandler(driver, false, null, false, "111111111111", "SomeRole",
+            message -> { }, cancelled);
+    }
+
+    @Test
+    void findsNeedleOnFirstAttemptWithoutSleeping() {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getPageSource()).thenReturn("<html>has-the-marker</html>");
+        BrowserLoginHandler handler = newHandler(driver, () -> false);
+
+        boolean found = handler.pollPageSourceWithBackoff("has-the-marker", Duration.ofSeconds(5),
+            TINY_DELAY, TINY_DELAY, 2.0);
+
+        assertTrue(found);
+    }
+
+    @Test
+    void findsNeedleAfterInitialMisses() {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getPageSource()).thenReturn(
+            "<html>nope</html>",
+            "<html>still-nope</html>",
+            "<html>has-the-marker</html>");
+        BrowserLoginHandler handler = newHandler(driver, () -> false);
+
+        boolean found = handler.pollPageSourceWithBackoff("has-the-marker", Duration.ofSeconds(5),
+            TINY_DELAY, TINY_DELAY, 2.0);
+
+        assertTrue(found);
+    }
+
+    @Test
+    void givesUpAfterDeadlineIfNeedleNeverAppears() {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getPageSource()).thenReturn("<html>nope</html>");
+        BrowserLoginHandler handler = newHandler(driver, () -> false);
+
+        boolean found = handler.pollPageSourceWithBackoff("has-the-marker", Duration.ofMillis(30),
+            TINY_DELAY, TINY_DELAY, 2.0);
+
+        assertFalse(found);
+    }
+
+    @Test
+    void throwsCancellationExceptionWhenCancelledBeforeAMatch() {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getPageSource()).thenReturn("<html>nope</html>");
+        BrowserLoginHandler handler = newHandler(driver, () -> true);
+
+        assertThrows(CancellationException.class, () ->
+            handler.pollPageSourceWithBackoff("has-the-marker", Duration.ofSeconds(5),
+                TINY_DELAY, TINY_DELAY, 2.0));
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #170: `BrowserLoginHandler.isPreAuthenticatedOktaMfaScreen()` waited for the "Back to sign in" link, then did a single immediate `pageSource.contains(...)` check for the MFA factor-selection markup, with no retry.
- Okta's factor-selection markup can render *after* "Back to sign in" is already in the DOM — especially on Firefox — so the one-shot check can miss it, and `handleOktaLogin()` falls through to filling a username field that isn't there (or eventually times out) instead of selecting the MFA method.
- This is the same bug shape already found and fixed upstream in the Python sibling (`aws-idp-saml` #83 / commit `7974321`), which replaced its one-shot check with `SeleniumHelper.poll_page_source_with_backoff()`.
- Ports that pattern here: a new `pollPageSourceWithBackoff()` on `BrowserLoginHandler` retries with exponentially increasing delay (1s → 4s cap, ×2 factor) bounded by a 20s overall deadline, replacing the single check. `isIntermediateVerifificationPage()`'s second check didn't need this — it already uses `WebDriverWait`/`ExpectedConditions`, which polls internally.
- Bumps `pom.xml` patch version 1.5.1 → 1.5.2.

## Test plan
- [x] New `BrowserLoginHandlerBackoffPollTest` (mocked `WebDriver`) covers: immediate match, match after initial misses, giving up at the deadline, and cancellation mid-poll — using millisecond-scale durations via a package-private overload so the suite stays fast.
- [x] `mvn test` passes in the Maven container.
- [x] `mvn package` builds cleanly.
- Not exercised: a live Okta MFA login (no test IdP available in this environment) — this doesn't touch a window/dialog/menu or bump a `pom.xml` dependency version, so per the `java-swing-ship-issue` verification bar, unit coverage of the timing/race logic plus a clean build is the appropriate level here.