### PR TITLE
Open ephemeral, cookie-isolated browser for Open Console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/core/SamlAuthenticator.java
+++ b/src/main/java/com/ourgiant/saml/core/SamlAuthenticator.java
@@ -1,10 +1,6 @@
 package com.ourgiant.saml.core;
 
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
@@ -176,36 +172,7 @@ public class SamlAuthenticator {
      * Create WebDriver instance based on configuration
      */
     private WebDriver createWebDriver(boolean showBrowser) {
-        String browserType = configManager.getBrowserType().toLowerCase();
-
-        switch (browserType) {
-            case "firefox":
-                return createFirefoxDriver(showBrowser);
-            case "chrome":
-            default:
-                return createChromeDriver(showBrowser);
-        }
-    }
-
-    private WebDriver createChromeDriver(boolean showBrowser) {
-        ChromeOptions options = new ChromeOptions();
-        System.setProperty("webdriver.manager.stats", "false");
-        if (!showBrowser) {
-            options.addArguments("--headless");
-        }
-        options.addArguments("--disable-dev-shm-usage");
-
-        return new ChromeDriver(options);
-    }
-
-    private WebDriver createFirefoxDriver(boolean showBrowser) {
-        FirefoxOptions options = new FirefoxOptions();
-        if (!showBrowser) {
-            options.addArguments("--headless");
-        }
-        System.setProperty("webdriver.manager.stats", "false");
-
-        return new FirefoxDriver(options);
+        return WebDriverFactory.createWebDriver(configManager.getBrowserType(), showBrowser);
     }
 
     /**

--- a/src/main/java/com/ourgiant/saml/core/WebDriverFactory.java
+++ b/src/main/java/com/ourgiant/saml/core/WebDriverFactory.java
@@ -1,0 +1,50 @@
+package com.ourgiant.saml.core;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+
+/**
+ * Creates Selenium WebDriver instances for the configured browser type. Shared by the SAML
+ * login flow (SamlAuthenticator) and ephemeral "Open Console" browser windows (SwingMain) —
+ * each caller gets its own driver instance, so each gets its own isolated cookie jar rather
+ * than colliding in the OS's shared default browser session.
+ */
+public class WebDriverFactory {
+
+    private WebDriverFactory() {
+    }
+
+    public static WebDriver createWebDriver(String browserType, boolean showBrowser) {
+        switch (browserType.toLowerCase()) {
+            case "firefox":
+                return createFirefoxDriver(showBrowser);
+            case "chrome":
+            default:
+                return createChromeDriver(showBrowser);
+        }
+    }
+
+    private static WebDriver createChromeDriver(boolean showBrowser) {
+        ChromeOptions options = new ChromeOptions();
+        System.setProperty("webdriver.manager.stats", "false");
+        if (!showBrowser) {
+            options.addArguments("--headless");
+        }
+        options.addArguments("--disable-dev-shm-usage");
+
+        return new ChromeDriver(options);
+    }
+
+    private static WebDriver createFirefoxDriver(boolean showBrowser) {
+        FirefoxOptions options = new FirefoxOptions();
+        if (!showBrowser) {
+            options.addArguments("--headless");
+        }
+        System.setProperty("webdriver.manager.stats", "false");
+
+        return new FirefoxDriver(options);
+    }
+}

--- a/src/main/java/com/ourgiant/saml/gui/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/gui/SwingMain.java
@@ -10,8 +10,10 @@ import com.ourgiant.saml.core.DatabaseManager;
 import com.ourgiant.saml.core.PasswordManager;
 import com.ourgiant.saml.core.SamlAuthenticator;
 import com.ourgiant.saml.core.TokenStateManager;
+import com.ourgiant.saml.core.WebDriverFactory;
 
 import com.formdev.flatlaf.FlatLaf;
+import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +39,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -92,6 +95,12 @@ public class SwingMain extends JFrame {
     private PasswordManager passwordManager;
     private BatchRefreshRunner batchRefreshRunner;
 
+    // Ephemeral, cookie-isolated browser windows opened by "Open Console" (see #169). Tracked
+    // so a JVM shutdown hook can quit() them: without it, EXIT_ON_CLOSE (no tray icon) and other
+    // exit paths bypass exitApplication() entirely and would leak orphaned chromedriver/
+    // geckodriver processes, the same failure mode already fixed once for the login flow (#84).
+    private final List<WebDriver> openConsoleDrivers = Collections.synchronizedList(new ArrayList<>());
+
     public SwingMain() {
         configManager = new ConfigManager();
         credentialManager = new CredentialManager();
@@ -99,6 +108,8 @@ public class SwingMain extends JFrame {
         databaseManager = new DatabaseManager();
         passwordManager = new PasswordManager(databaseManager);
         batchRefreshRunner = new BatchRefreshRunner(configManager, credentialManager, passwordManager, databaseManager);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(this::quitOpenConsoleDrivers, "console-driver-cleanup"));
 
         // Set theme
         setLookAndFeel();
@@ -524,6 +535,19 @@ public class SwingMain extends JFrame {
             SystemTray.getSystemTray().remove(trayIcon);
         }
         System.exit(0);
+    }
+
+    private void quitOpenConsoleDrivers() {
+        synchronized (openConsoleDrivers) {
+            for (WebDriver driver : openConsoleDrivers) {
+                try {
+                    driver.quit();
+                } catch (Exception e) {
+                    logger.warn("Failed to close a console browser window on shutdown", e);
+                }
+            }
+            openConsoleDrivers.clear();
+        }
     }
 
     private void startStatusPolling() {
@@ -1363,10 +1387,23 @@ public class SwingMain extends JFrame {
         openConsoleButton.setText("Opening...");
         statusLabel.setText("Opening AWS Console for profile: " + selectedProfile + "...");
 
-        SwingWorker<String, Void> worker = new SwingWorker<>() {
+        SwingWorker<Void, Void> worker = new SwingWorker<>() {
             @Override
-            protected String doInBackground() throws Exception {
-                return AwsConsoleLauncher.buildLoginUrl(credentials);
+            protected Void doInBackground() throws Exception {
+                String loginUrl = AwsConsoleLauncher.buildLoginUrl(credentials);
+
+                // A fresh WebDriver per click gives this console session its own cookie jar,
+                // so it doesn't collide with sessions already open for other profiles (#169).
+                WebDriver driver = WebDriverFactory.createWebDriver(configManager.getBrowserType(), true);
+                openConsoleDrivers.add(driver);
+                try {
+                    driver.get(loginUrl);
+                } catch (Exception e) {
+                    openConsoleDrivers.remove(driver);
+                    driver.quit();
+                    throw e;
+                }
+                return null;
             }
 
             @Override
@@ -1375,8 +1412,7 @@ public class SwingMain extends JFrame {
                 openConsoleButton.setText("Open Console");
 
                 try {
-                    String loginUrl = get();
-                    Desktop.getDesktop().browse(new java.net.URI(loginUrl));
+                    get();
                     statusLabel.setText("Opened AWS Console for profile: " + selectedProfile);
                 } catch (Exception ex) {
                     statusLabel.setText("Failed to open AWS Console: " + ex.getMessage());


### PR DESCRIPTION
## Summary
- Fixes #169: "Open Console" now launches a fresh, Selenium-driven browser window per click instead of handing the sign-in URL to the OS's shared default browser via `Desktop.browse()`. Each window gets its own cookie jar, so switching profiles no longer hits AWS's "you must log out first" page — different profiles' consoles can even stay open side by side.
- Extracted `SamlAuthenticator`'s Chrome/FirefoxDriver creation into a new `WebDriverFactory` shared by both the SAML login flow and the new "Open Console" path, so both get the same isolated-session behavior.
- Tracks opened console-browser `WebDriver`s on `SwingMain` and quits them via a JVM shutdown hook, so exit paths that bypass `exitApplication()` (e.g. `EXIT_ON_CLOSE` when the tray icon fails to init) don't leak orphaned `chromedriver`/`geckodriver` processes — the same class of bug already fixed once for the login flow in #84.
- Bumped `pom.xml` to 1.5.3 per this repo's per-issue patch-bump convention.

## Test plan
- [x] `mvn test` passes in the Docker build container
- [x] `mvn package -DskipTests` builds the jar cleanly
- [x] Standalone Selenium harness confirms two `WebDriverFactory`-created Chrome instances never share cookies (the core mechanism behind the fix) — verified against a local HTTP server tracking `Cookie` headers per request
- [x] Live UI harness: launched the real app with a fake `$HOME`/saved credentials, clicked "Open Console", confirmed the refactored `SwingWorker` failure path correctly re-enables the button, resets its text, and surfaces the error (fake creds correctly fail at AWS's federation endpoint, before ever reaching driver creation)
- [x] Live UI harness: injected a real driver into `SwingMain`'s tracked list and confirmed `quitOpenConsoleDrivers()` actually quits it and clears the list
- [x] Confirmed no orphaned Chrome/chromedriver processes remained after any of the above runs