### PR TITLE
Auto-renew pinned profiles when expiring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/core/DatabaseManager.java
+++ b/src/main/java/com/ourgiant/saml/core/DatabaseManager.java
@@ -212,6 +212,15 @@ public class DatabaseManager {
         setConfig("tray_notifications_enabled", String.valueOf(enabled));
     }
 
+    public boolean getAutoRenewPinnedProfilesEnabled() {
+        String value = getConfig("auto_renew_pinned_profiles_enabled");
+        return "true".equalsIgnoreCase(value); // Disabled by default -- opt in before the app starts unattended browser logins
+    }
+
+    public void setAutoRenewPinnedProfilesEnabled(boolean enabled) {
+        setConfig("auto_renew_pinned_profiles_enabled", String.valueOf(enabled));
+    }
+
     // Intentionally not seeded in insertDefaultConfig(): an absent value lets
     // ConfigManager.getBrowserType() fall back to the samlsts "browser" key
     // (set during first-run setup) until the user explicitly saves a choice here.

--- a/src/main/java/com/ourgiant/saml/gui/ConfigurationDialog.java
+++ b/src/main/java/com/ourgiant/saml/gui/ConfigurationDialog.java
@@ -34,6 +34,7 @@ public class ConfigurationDialog extends JDialog {
     private JComboBox<String> browserComboBox;
     private JCheckBox useFastPassCheckBox;
     private JCheckBox trayNotificationsCheckBox;
+    private JCheckBox autoRenewPinnedProfilesCheckBox;
     private JCheckBox startMinimizedCheckBox;
     private JButton forceRefreshButton;
     private JButton saveButton;
@@ -202,6 +203,16 @@ public class ConfigurationDialog extends JDialog {
             : "System tray is not available on this platform/environment");
         panel.add(trayNotificationsCheckBox, gbc);
 
+        gbc.gridy = 1;
+        autoRenewPinnedProfilesCheckBox = new JCheckBox("Automatically renew pinned profiles when expiring");
+        autoRenewPinnedProfilesCheckBox.setMnemonic(KeyEvent.VK_R);
+        autoRenewPinnedProfilesCheckBox.setToolTipText(
+            "Silently refresh pinned profiles' credentials via headless browser login once they're expired "
+                + "or expiring soon, without waiting for you to ask. A tray notification announces each "
+                + "renewal attempt; profiles that need an interactive login step (e.g. MFA) will keep "
+                + "failing until refreshed manually.");
+        panel.add(autoRenewPinnedProfilesCheckBox, gbc);
+
         return panel;
     }
 
@@ -313,6 +324,8 @@ public class ConfigurationDialog extends JDialog {
 
         trayNotificationsCheckBox.setSelected(databaseManager.getTrayNotificationsEnabled());
 
+        autoRenewPinnedProfilesCheckBox.setSelected(databaseManager.getAutoRenewPinnedProfilesEnabled());
+
         startMinimizedCheckBox.setSelected(databaseManager.getStartMinimizedToTray());
 
         updatePasswordExpirationEnabled();
@@ -344,11 +357,14 @@ public class ConfigurationDialog extends JDialog {
                 boolean trayNotificationsEnabled = trayNotificationsCheckBox.isSelected();
                 databaseManager.setTrayNotificationsEnabled(trayNotificationsEnabled);
 
+                boolean autoRenewPinnedProfiles = autoRenewPinnedProfilesCheckBox.isSelected();
+                databaseManager.setAutoRenewPinnedProfilesEnabled(autoRenewPinnedProfiles);
+
                 boolean startMinimized = startMinimizedCheckBox.isSelected();
                 databaseManager.setStartMinimizedToTray(startMinimized);
 
-                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, browser = {}, use_fastpass = {}, tray_notifications = {}, start_minimized_to_tray = {}",
-                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, selectedBrowser, useFastPass, trayNotificationsEnabled, startMinimized);
+                logger.info("Configuration saved: session_duration = {} seconds, store_password = {}, password_expiration = {} minutes, theme = {}, browser = {}, use_fastpass = {}, tray_notifications = {}, auto_renew_pinned_profiles = {}, start_minimized_to_tray = {}",
+                    durationSeconds, storePassword, passwordExpirationMinutes, selectedTheme, selectedBrowser, useFastPass, trayNotificationsEnabled, autoRenewPinnedProfiles, startMinimized);
 
                 // Apply theme immediately — ThemeManager refreshes all open windows,
                 // including this dialog, so it re-themes live.

--- a/src/main/java/com/ourgiant/saml/gui/SwingMain.java
+++ b/src/main/java/com/ourgiant/saml/gui/SwingMain.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Main Swing application for AWS SAML authentication
@@ -55,6 +56,11 @@ import java.util.regex.Pattern;
 public class SwingMain extends JFrame {
     private static final Logger logger = LoggerFactory.getLogger(SwingMain.class);
     private static final Duration EXPIRY_WARNING_THRESHOLD = Duration.ofMinutes(5);
+    // How long to wait before retrying an auto-renew attempt for the same pinned profile after
+    // one fails (e.g. it needs an interactive MFA step auto-renew can't complete headlessly) --
+    // without this, a profile stuck in that state would be retried every statusRefreshTimer
+    // tick (30s), hammering the SSO provider indefinitely.
+    private static final Duration AUTO_RENEW_RETRY_COOLDOWN = Duration.ofMinutes(5);
 
     private JComboBox<String> profileComboBox;
     private JCheckBox showBrowserCheckBox;
@@ -85,6 +91,7 @@ public class SwingMain extends JFrame {
 
     private TrayIcon trayIcon;
     private final Map<String, Instant> lastNotifiedExpiration = new HashMap<>();
+    private final Map<String, Instant> lastAutoRenewAttempt = new HashMap<>();
     private final Set<String> expiringSoonProfiles = new HashSet<>();
     private final List<String> pinnedProfileOrder = new ArrayList<>();
 
@@ -649,6 +656,8 @@ public class SwingMain extends JFrame {
             if (!credentialRequestInProgress) {
                 statusLabel.setText("Status refreshed.");
             }
+
+            maybeAutoRenewPinnedProfiles();
         } catch (Exception e) {
             if (!credentialRequestInProgress) {
                 statusLabel.setText("Failed to update status table: " + e.getMessage());
@@ -901,6 +910,73 @@ public class SwingMain extends JFrame {
     }
 
     /**
+     * Silently kicks off a headless refresh for pinned profiles that are expired or expiring
+     * soon, when the user has opted into "auto-renew pinned profiles" (#173). Runs from the
+     * same status-polling tick that already computes expiringSoonProfiles, rather than a
+     * separate timer. Unlike the menu-driven batch-refresh actions, this never prompts for
+     * confirmation and never pops a completion dialog — it's a background timer tick, and an
+     * unattended modal dialog would be disruptive — so a tray notification announces the
+     * kickoff instead, and failures are reported the same way rather than silently swallowed.
+     */
+    private void maybeAutoRenewPinnedProfiles() {
+        if (!databaseManager.getAutoRenewPinnedProfilesEnabled() || credentialRequestInProgress) {
+            return;
+        }
+
+        Set<String> pinnedDueProfiles = new HashSet<>();
+        for (int row = 0; row < tokenStatusTableModel.getRowCount(); row++) {
+            String profile = (String) tokenStatusTableModel.getValueAt(row, 0);
+            String status = (String) tokenStatusTableModel.getValueAt(row, 1);
+            if (pinnedProfileOrder.contains(profile) && ("EXPIRED".equals(status) || expiringSoonProfiles.contains(profile))) {
+                pinnedDueProfiles.add(profile);
+            }
+        }
+
+        // A pinned profile that's no longer due (renewed, unpinned, or removed) starts with a
+        // fresh retry budget the next time it becomes due, rather than inheriting a stale cooldown.
+        lastAutoRenewAttempt.keySet().retainAll(pinnedDueProfiles);
+
+        Instant now = Instant.now();
+        List<String> targets = new ArrayList<>();
+        for (String profile : pinnedDueProfiles) {
+            Instant lastAttempt = lastAutoRenewAttempt.get(profile);
+            if (lastAttempt == null || Duration.between(lastAttempt, now).compareTo(AUTO_RENEW_RETRY_COOLDOWN) >= 0) {
+                targets.add(profile);
+            }
+        }
+
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        for (String profile : targets) {
+            lastAutoRenewAttempt.put(profile, now);
+        }
+
+        if (trayIcon != null && databaseManager.getTrayNotificationsEnabled()) {
+            trayIcon.displayMessage(
+                "Auto-renewing pinned profile(s)",
+                "Starting credential renewal for: " + String.join(", ", targets),
+                TrayIcon.MessageType.INFO
+            );
+        }
+
+        startBatchRefresh(targets, false);
+    }
+
+    private void notifyAutoRenewFailures(List<BatchRefreshRunner.Result> failures) {
+        if (trayIcon == null || !databaseManager.getTrayNotificationsEnabled()) {
+            return;
+        }
+        String profiles = failures.stream().map(BatchRefreshRunner.Result::profile).collect(Collectors.joining(", "));
+        trayIcon.displayMessage(
+            "Auto-renew failed",
+            "Could not renew: " + profiles + ". Refresh manually when convenient.",
+            TrayIcon.MessageType.ERROR
+        );
+    }
+
+    /**
      * Refreshes exactly the profile(s) currently selected in the status table, regardless of
      * their current status (#127) — e.g. proactively refreshing a still-valid profile before a
      * work session is a legitimate reason to select it, not just expired/expiring ones.
@@ -967,6 +1043,17 @@ public class SwingMain extends JFrame {
             return;
         }
 
+        startBatchRefresh(targets, true);
+    }
+
+    /**
+     * Shared by the interactive batch-refresh actions (which have already confirmed with the
+     * user and want a completion summary dialog) and the silent auto-renew-pinned-profiles
+     * check (which never prompts and only ever surfaces a tray notification, see
+     * maybeAutoRenewPinnedProfiles()) — drives the actual SwingWorker/BatchRefreshRunner
+     * execution and the busy UI state shared with the single-profile request flow.
+     */
+    private void startBatchRefresh(List<String> targets, boolean interactive) {
         batchRefreshMenuItem.setEnabled(false);
         refreshSelectedMenuItem.setEnabled(false);
         batchCancelButton.setVisible(true);
@@ -1035,29 +1122,38 @@ public class SwingMain extends JFrame {
                         "Batch refresh complete: %d succeeded, %d failed.", succeeded, failures.size()));
                 }
 
-                if (failures.isEmpty() && !cancelled) {
-                    JOptionPane.showMessageDialog(SwingMain.this,
-                        "Refreshed " + succeeded + " profile(s) successfully.",
-                        "Batch Refresh Complete",
-                        JOptionPane.INFORMATION_MESSAGE);
-                } else {
-                    StringBuilder detail = new StringBuilder();
-                    detail.append(succeeded).append(" succeeded, ").append(failures.size()).append(" failed");
-                    if (cancelled) {
-                        detail.append(", ").append(notAttempted).append(" not attempted (cancelled)");
-                    }
-                    detail.append(".\n");
-                    for (BatchRefreshRunner.Result r : failures) {
-                        detail.append("\n- ").append(r.profile()).append(": ").append(r.detail());
-                    }
-                    JOptionPane.showMessageDialog(SwingMain.this,
-                        scrollableMessage(detail.toString()),
-                        cancelled ? "Batch Refresh Cancelled" : "Batch Refresh Complete With Errors",
-                        JOptionPane.WARNING_MESSAGE);
+                if (interactive) {
+                    showBatchRefreshCompletionDialog(succeeded, failures, cancelled, notAttempted);
+                } else if (!failures.isEmpty()) {
+                    notifyAutoRenewFailures(failures);
                 }
             }
         };
         worker.execute();
+    }
+
+    private void showBatchRefreshCompletionDialog(long succeeded, List<BatchRefreshRunner.Result> failures,
+                                                    boolean cancelled, int notAttempted) {
+        if (failures.isEmpty() && !cancelled) {
+            JOptionPane.showMessageDialog(SwingMain.this,
+                "Refreshed " + succeeded + " profile(s) successfully.",
+                "Batch Refresh Complete",
+                JOptionPane.INFORMATION_MESSAGE);
+        } else {
+            StringBuilder detail = new StringBuilder();
+            detail.append(succeeded).append(" succeeded, ").append(failures.size()).append(" failed");
+            if (cancelled) {
+                detail.append(", ").append(notAttempted).append(" not attempted (cancelled)");
+            }
+            detail.append(".\n");
+            for (BatchRefreshRunner.Result r : failures) {
+                detail.append("\n- ").append(r.profile()).append(": ").append(r.detail());
+            }
+            JOptionPane.showMessageDialog(SwingMain.this,
+                scrollableMessage(detail.toString()),
+                cancelled ? "Batch Refresh Cancelled" : "Batch Refresh Complete With Errors",
+                JOptionPane.WARNING_MESSAGE);
+        }
     }
 
     private void showCredentialErrorDialog(String selectedProfile, CredentialRequestError error) {


### PR DESCRIPTION
## Summary
- Fixes #173: adds an "Automatically renew pinned profiles when expiring" toggle (Configuration > Notifications, disabled by default). When enabled, the existing 30s status-polling tick that already computes `expiringSoonProfiles`/EXPIRED status also silently kicks off a headless batch refresh for any **pinned** profile that's due — no separate timer needed.
- Kickoff is announced via a tray notification (per the issue's requirement); since this runs unattended from a background timer rather than a user action, it deliberately never prompts for confirmation and never pops a completion dialog like the menu-driven "Refresh Expiring/Expired Profiles" action does — a modal dialog appearing unattended would be disruptive. Failures are reported via tray notification too, rather than silently swallowed.
- A profile that can't renew headlessly (e.g. needs an interactive MFA step) is retried at most once every 5 minutes, not every 30-second tick — otherwise a stuck profile would hammer the SSO provider indefinitely.
- Extracted the shared SwingWorker/BatchRefreshRunner execution logic out of `runBatchRefresh()` into `startBatchRefresh(targets, interactive)`, used by both the interactive menu actions and the new silent auto-renew path; the completion-dialog logic moved into `showBatchRefreshCompletionDialog()`.
- Bumped `pom.xml` to 1.5.4 per this repo's per-issue patch-bump convention.

## Test plan
- [x] `mvn test` passes in the Docker build container
- [x] `mvn package -DskipTests` builds the jar cleanly
- [x] Live UI harness against the real app:
  - Checked the new checkbox in the real Configuration dialog, clicked Save, confirmed `DatabaseManager.getAutoRenewPinnedProfilesEnabled()` persisted the change
  - Seeded two EXPIRED profiles, pinned only one via the real `toggleProfilePinned()` path, confirmed the resulting auto-renew batch targeted **only** the pinned profile (unpinned expired profile correctly excluded)
  - Confirmed an immediate second status-refresh tick did **not** re-trigger a batch (retry cooldown working)
  - Confirmed the failure path (fake SAML provider URL) completes cleanly with no orphaned Chrome/chromedriver processes