### PR TITLE
Detect Okta's forced password-reset screen and fail fast

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ourgiant</groupId>
     <artifactId>aws-idp-saml-ui</artifactId>
-    <version>1.5.4</version>
+    <version>1.5.5</version>
     <packaging>jar</packaging>
 
     <name>AWS IDP SAML UI Client</name>

--- a/src/main/java/com/ourgiant/saml/core/BrowserLoginHandler.java
+++ b/src/main/java/com/ourgiant/saml/core/BrowserLoginHandler.java
@@ -36,6 +36,14 @@ public class BrowserLoginHandler {
     private static final Duration BACKOFF_MAX_DELAY = Duration.ofSeconds(4);
     private static final double BACKOFF_FACTOR = 2.0;
 
+    // Okta's i18n key for this screen's heading (login.reset.password.headline / similar) renders
+    // as this exact string on both the default hosted widget and custom SIW-based embedded flows
+    // (#172), so it's a more stable signal than guessing at form/field markup we haven't observed
+    // in this app's own driver yet. If this ever needs replacing, a real occurrence should now get
+    // captured by captureFailureScreenshot() before the login times out below.
+    private static final String FORCED_PASSWORD_RESET_INDICATOR = "Reset your Okta password";
+    private static final Duration FORCED_PASSWORD_RESET_POLL_TIMEOUT = Duration.ofSeconds(5);
+
     private final WebDriver driver;
     private final WebDriverWait wait;
     private final boolean useOktaFastPass;
@@ -238,6 +246,13 @@ public class BrowserLoginHandler {
             throw e;
         }
 
+        statusCallback.accept("Checking for forced Okta password-reset screen...");
+        if (isForcedPasswordResetScreen()) {
+            logger.warn("Detected forced Okta password-reset screen after primary authentication");
+            throw new RuntimeException("Your Okta password needs to be reset before you can sign in. "
+                + "Please log in to Okta via your browser to reset it, then try again.");
+        }
+
         if (useOktaFastPass) {
             statusCallback.accept("Selecting Okta FastPass...");
             clickOktaFastPassSelection();
@@ -269,6 +284,16 @@ public class BrowserLoginHandler {
             logger.warn("Error while checking for intermediate verification page", e);
             return false;
         }
+    }
+
+    /**
+     * Detects Okta's forced "Reset your Okta password" interstitial, which some password
+     * policies substitute for the MFA screen right after primary authentication succeeds (#172).
+     * Unlike {@link #isPreAuthenticatedOktaMfaScreen()}, there's no known gating element to check
+     * first, so this polls the page source directly for the screen's heading text.
+     */
+    private boolean isForcedPasswordResetScreen() {
+        return pollPageSourceWithBackoff(FORCED_PASSWORD_RESET_INDICATOR, FORCED_PASSWORD_RESET_POLL_TIMEOUT);
     }
 
     private void clickUsePassword() {

--- a/src/test/java/com/ourgiant/saml/core/BrowserLoginHandlerBackoffPollTest.java
+++ b/src/test/java/com/ourgiant/saml/core/BrowserLoginHandlerBackoffPollTest.java
@@ -61,6 +61,34 @@ class BrowserLoginHandlerBackoffPollTest {
     }
 
     @Test
+    void detectsForcedPasswordResetScreenByHeadingText() {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getPageSource()).thenReturn(
+            "<html><body><h1>Reset your Okta password</h1>"
+            + "<input name=\"newPassword\"/><input name=\"confirmPassword\"/>"
+            + "<button>Reset Password</button></body></html>");
+        BrowserLoginHandler handler = newHandler(driver, () -> false);
+
+        boolean found = handler.pollPageSourceWithBackoff("Reset your Okta password", Duration.ofSeconds(5),
+            TINY_DELAY, TINY_DELAY, 2.0);
+
+        assertTrue(found);
+    }
+
+    @Test
+    void doesNotMistakeMfaSelectionScreenForPasswordReset() {
+        WebDriver driver = mock(WebDriver.class);
+        when(driver.getPageSource()).thenReturn(
+            "<html><body><a class=\"button select-factor link-button\">Select Okta Verify.</a></body></html>");
+        BrowserLoginHandler handler = newHandler(driver, () -> false);
+
+        boolean found = handler.pollPageSourceWithBackoff("Reset your Okta password", Duration.ofMillis(30),
+            TINY_DELAY, TINY_DELAY, 2.0);
+
+        assertFalse(found);
+    }
+
+    @Test
     void throwsCancellationExceptionWhenCancelledBeforeAMatch() {
         WebDriver driver = mock(WebDriver.class);
         when(driver.getPageSource()).thenReturn("<html>nope</html>");


### PR DESCRIPTION
## Summary
- Fixes #172: adds detection for Okta's forced "Reset your Okta password" interstitial, which some password policies substitute for the MFA screen right after primary authentication succeeds. Previously nothing recognized this screen, so a headless login would just silently hang until an unrelated SAML-redirect timeout, with a generic error message.
- Adds `isForcedPasswordResetScreen()` in `BrowserLoginHandler`, checked right after the sign-in button click (before the code assumes it can proceed to MFA selection). Detection matches on the screen's heading text, since that's the most stable signal available without a confirmed real occurrence of this app's own rendered markup (per the issue, only one example screenshot exists, from a differently-built Okta widget flow). On match, fails fast with an actionable error instead of running out the clock.
- Checked the Python sibling (`aws-idp-saml`) for existing handling of this screen — it has none, so there was nothing to port.
- Bumped `pom.xml` patch version 1.5.4 → 1.5.5 per this repo's convention.

Deliberately out of scope: automatically falling back to a visible browser window so the user can complete the reset in place (raised as a "consider" in the issue, not a requirement) — that's a larger behavior change better suited to its own issue/PR once the actual markup is confirmed.

## Test plan
- [x] `mvn test` — full suite green, including two new unit tests covering the new detection string (matches a realistic reset-screen snippet, doesn't false-positive on the existing MFA-selection screen markup)
- [x] `mvn clean package` — builds cleanly
- [ ] Live verification against a real Okta forced-reset screen isn't possible in this environment (no real IdP/test account that can trigger it) — the detection string should be reconfirmed against a real occurrence per the issue's own caveat, ideally using the failure-screenshot capture already in place (`~/.aws/login-failure-screenshots/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)